### PR TITLE
Add support for Hadoop paths

### DIFF
--- a/src/main/scala/com/crealytics/spark/excel/ExcelRelation.scala
+++ b/src/main/scala/com/crealytics/spark/excel/ExcelRelation.scala
@@ -29,7 +29,6 @@ extends BaseRelation with TableScan with PrunedScan {
   val path = new Path(location)
   val inputStream = FileSystem.get(path.toUri, sqlContext.sparkContext.hadoopConfiguration).open(path)
   val workbook = WorkbookFactory.create(inputStream)
-  inputStream.close()
   val sheet = findSheet(workbook, sheetName)
   val headers = sheet.getRow(0).cellIterator().asScala.to[Vector]
   override val schema: StructType = inferSchema

--- a/src/main/scala/com/crealytics/spark/excel/ExcelRelation.scala
+++ b/src/main/scala/com/crealytics/spark/excel/ExcelRelation.scala
@@ -11,6 +11,7 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.sql._
 import org.apache.spark.sql.sources._
 import org.apache.spark.sql.types._
+import org.apache.hadoop.fs.{FileSystem, Path}
 
 import scala.util.Try
 
@@ -25,7 +26,10 @@ case class ExcelRelation(
   )
   (@transient val sqlContext: SQLContext)
 extends BaseRelation with TableScan with PrunedScan {
-  val workbook = WorkbookFactory.create(new FileInputStream(location))
+  val path = new Path(location)
+  val inputStream = FileSystem.get(path.toUri, sqlContext.sparkContext.hadoopConfiguration).open(path)
+  val workbook = WorkbookFactory.create(inputStream)
+  inputStream.close()
   val sheet = findSheet(workbook, sheetName)
   val headers = sheet.getRow(0).cellIterator().asScala.to[Vector]
   override val schema: StructType = inferSchema
@@ -34,7 +38,7 @@ extends BaseRelation with TableScan with PrunedScan {
   private def findSheet(workBook: Workbook, sheetName: Option[String]): Sheet = {
     sheetName.map { sn =>
       Option(workBook.getSheet(sn)).getOrElse(
-          throw new IllegalArgumentException(s"Unknow sheet $sn")
+          throw new IllegalArgumentException(s"Unknown sheet $sn")
         )
     }.getOrElse(workBook.sheetIterator.next)
   }


### PR DESCRIPTION
Trying to load an Excel file from a Hadoop path (such as hdfs://localhost/users/shoffing/test_excel.xlsx) wasn't working. This change adds support for loading excel files from Hadoop and hdfs.

Also fix a tiny typo in an error message.