### PR TITLE
Sparse sheets fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,8 +37,13 @@ matrix:
     - jdk: openjdk7
       scala: 2.11.7
       env: TEST_SPARK_VERSION="2.0.0"
+    # Spark 2.1.1
+    - jdk: openjdk7
+      scala: 2.11.8
+      env: TEST_SPARK_VERSION="2.1.1"
 script:
   - sbt -Dspark.testVersion=$TEST_SPARK_VERSION ++$TRAVIS_SCALA_VERSION compile
+  - sbt ++$TRAVIS_SCALA_VERSION test
   - sbt ++$TRAVIS_SCALA_VERSION assembly
   - sbt ++$TRAVIS_SCALA_VERSION scalastyle
   - sbt ++$TRAVIS_SCALA_VERSION "test:scalastyle"

--- a/README.md
+++ b/README.md
@@ -55,8 +55,11 @@ val df = sqlContext.read
     .option("sheetName", "Daily")
     .option("useHeader", "true")
     .option("treatEmptyValuesAsNulls", "true")
+    .option("userSchema", StructType(???)) // Optional
     .option("inferSchema", "true")
     .option("addColorColumns", "true")
+    .option("startColumn", 0) // Optional
+    .option("endColumn", 99) // Optional
     .load()
 ```
 

--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ spName := "crealytics/spark-excel"
 
 crossScalaVersions := Seq("2.10.6", "2.11.8")
 
-sparkVersion := "2.0.0"
+sparkVersion := "2.1.1"
 
 val testSparkVersion = settingKey[String]("The version of Spark to test against.")
 
@@ -20,7 +20,7 @@ sparkComponents := Seq("core", "sql")
 
 libraryDependencies ++= Seq(
   "org.slf4j" % "slf4j-api" % "1.7.5" % "provided",
-  "org.apache.poi" % "poi-ooxml" % "3.14"
+  "org.apache.poi" % "poi-ooxml" % "3.16"
 )
 
 libraryDependencies ++= Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 name := "spark-excel"
 
-version := "0.8.3"
+version := "0.8.4-SNAPSHOT"
 
 organization := "com.crealytics"
 
@@ -21,6 +21,12 @@ sparkComponents := Seq("core", "sql")
 libraryDependencies ++= Seq(
   "org.slf4j" % "slf4j-api" % "1.7.5" % "provided",
   "org.apache.poi" % "poi-ooxml" % "3.14"
+)
+
+libraryDependencies ++= Seq(
+  "org.scalatest" %% "scalatest" % "3.0.1" % Test,
+  "org.scalacheck" %% "scalacheck" % "1.13.4" % Test,
+  "org.scalamock" %% "scalamock-scalatest-support" % "3.5.0" % Test
 )
 
 publishMavenStyle := true

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 resolvers += "Spark Package Main Repo" at "https://dl.bintray.com/spark-packages/maven"
 
-addSbtPlugin("org.spark-packages" % "sbt-spark-package" % "0.2.5")
+addSbtPlugin("org.spark-packages" % "sbt-spark-package" % "0.2.6")
 
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.7.0" excludeAll(
   ExclusionRule(organization = "com.danieltrinh")))

--- a/src/main/scala/com/crealytics/spark/excel/DefaultSource.scala
+++ b/src/main/scala/com/crealytics/spark/excel/DefaultSource.scala
@@ -13,22 +13,16 @@ class DefaultSource
   override def createRelation(
                                sqlContext: SQLContext,
                                parameters: Map[String, String]): ExcelRelation = {
-
-    val location = checkParameter(parameters, "location")
-    val sheetName = parameters.get("sheetName")
-    val useHeader = checkParameter(parameters, "useHeader").toBoolean
-    val treatEmptyValuesAsNulls = checkParameter(parameters, "treatEmptyValuesAsNulls").toBoolean
-    val userSchema = null // checkParameter(parameters, "userSchema")
-    val inferSchema = checkParameter(parameters, "inferSchema").toBoolean
-    val addColorColumns = checkParameter(parameters, "addColorColumns").toBoolean
     ExcelRelation(
-      location,
-      sheetName,
-      useHeader,
-      treatEmptyValuesAsNulls,
-      inferSchema,
-      addColorColumns
-      )(sqlContext)
+      location = checkParameter(parameters, "location"),
+      sheetName = parameters.get("sheetName"),
+      useHeader = checkParameter(parameters, "useHeader").toBoolean,
+      treatEmptyValuesAsNulls = checkParameter(parameters, "treatEmptyValuesAsNulls").toBoolean,
+      inferSheetSchema = checkParameter(parameters, "inferSchema").toBoolean,
+      addColorColumns = checkParameter(parameters, "addColorColumns").toBoolean,
+      startColumn = parameters.get("startColumn").fold(0)(_.toInt),
+      endColumn = parameters.get("endColumn").fold(Int.MaxValue)(_.toInt)
+    )(sqlContext)
   }
 
   // Forces a Parameter to exist, otherwise an exception is thrown.

--- a/src/main/scala/com/crealytics/spark/excel/package.scala
+++ b/src/main/scala/com/crealytics/spark/excel/package.scala
@@ -1,0 +1,29 @@
+package com.crealytics.spark
+
+import org.apache.poi.ss.usermodel.Row.MissingCellPolicy
+import org.apache.poi.ss.usermodel.{Cell, Row}
+
+package object excel {
+
+  implicit class RichRow(val row: Row) extends AnyVal {
+
+    def eachCellIterator(startColumn: Int, endColumn: Int): Iterator[Option[Cell]] = new Iterator[Option[Cell]] {
+      private val lastCellInclusive = row.getLastCellNum - 1
+      private val endCol = Math.min(endColumn, Math.max(startColumn, lastCellInclusive))
+      require(startColumn >= 0 && startColumn <= endCol)
+
+      private var nextCol = startColumn
+
+      override def hasNext: Boolean = nextCol <= endCol && nextCol <= lastCellInclusive
+
+      override def next(): Option[Cell] = {
+        val next = if (nextCol > endCol) throw new NoSuchElementException(s"column index = $nextCol")
+          else Option(row.getCell(nextCol, MissingCellPolicy.RETURN_NULL_AND_BLANK))
+        nextCol += 1
+        next
+      }
+    }
+
+  }
+
+}

--- a/src/test/scala/com/crealytics/spark/excel/RichRowSuite.scala
+++ b/src/test/scala/com/crealytics/spark/excel/RichRowSuite.scala
@@ -1,0 +1,54 @@
+package com.crealytics.spark.excel
+
+import org.apache.poi.ss.usermodel.{Cell, Row}
+import org.scalacheck.Gen
+import org.scalacheck.Prop.BooleanOperators
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.FunSuite
+import org.scalatest.prop.PropertyChecks
+
+import scala.util.Try
+
+trait RowGenerator extends MockFactory {
+  private val MAX_WIDTH = 100
+
+  protected case class GeneratedRow(start: Int, end: Int, lastCellNum: Int, row: Row)
+
+  protected val rowGen: Gen[GeneratedRow] = for {
+    startColumn <- Gen.choose(0, MAX_WIDTH - 1)
+    endColumn <- Gen.choose(0, MAX_WIDTH - 1)
+    lastCellNum <- Gen.choose(0, MAX_WIDTH - 1)
+    row = stub[Row]
+    _ = (row.getCell(_: Int)).when(*) returns stub[Cell]
+    _ = row.getLastCellNum _ when() returns lastCellNum.toShort
+
+  } yield GeneratedRow(startColumn, endColumn, lastCellNum, row)
+}
+
+class RichRowSuite extends FunSuite with PropertyChecks with RowGenerator {
+
+  test("Invalid cell range should throw an error") {
+    forAll(rowGen) { g =>
+      (g.start > g.end) ==> Try {
+        g.row.eachCellIterator(g.start, g.end).next()
+      }.isFailure
+    }
+  }
+
+  test("Valid cell range should iterate through all non-empty cells") {
+    forAll(rowGen) { g =>
+      (g.start <= g.end && g.start < g.lastCellNum) ==> {
+        val count = g.row.eachCellIterator(g.start, g.end).size
+        count === Math.min(g.end, g.lastCellNum - 1) - g.start + 1
+      }
+    }
+  }
+
+  test("Valid cell range should should not iterate through non-empty cells") {
+    forAll(rowGen) { g =>
+      (g.start <= g.end && g.start >= g.lastCellNum) ==> {
+        g.row.eachCellIterator(g.start, g.end).size === 0
+      }
+    }
+  }
+}


### PR DESCRIPTION
Changes:
- fixed column names generation and schema inference for sparse sheets (with lots of nulls);
`row.cellIterator()` did not work good in this case.
- library versions updated.
- two more optional options (hehe) added for selective load (startColumn/endCoumn, inclusive) 