### PR TITLE
allow timestamp format to be specified if desired

### DIFF
--- a/src/main/scala/com/crealytics/spark/excel/DefaultSource.scala
+++ b/src/main/scala/com/crealytics/spark/excel/DefaultSource.scala
@@ -38,7 +38,8 @@ class DefaultSource
       inferSheetSchema = parameters.get("inferSchema").fold(false)(_.toBoolean),
       addColorColumns = parameters.get("addColorColumns").fold(false)(_.toBoolean),
       startColumn = parameters.get("startColumn").fold(0)(_.toInt),
-      endColumn = parameters.get("endColumn").fold(Int.MaxValue)(_.toInt)
+      endColumn = parameters.get("endColumn").fold(Int.MaxValue)(_.toInt),
+      timestampFormat = parameters.get("timestampFormat")
     )(sqlContext)
   }
 

--- a/src/main/scala/com/crealytics/spark/excel/ExcelRelation.scala
+++ b/src/main/scala/com/crealytics/spark/excel/ExcelRelation.scala
@@ -2,7 +2,7 @@ package com.crealytics.spark.excel
 
 import java.math.BigDecimal
 import java.sql.{Date, Timestamp}
-import java.text.NumberFormat
+import java.text.{NumberFormat, SimpleDateFormat}
 import java.util.Locale
 
 import org.apache.hadoop.fs.{FileSystem, Path}
@@ -25,7 +25,8 @@ case class ExcelRelation(
   addColorColumns: Boolean = true,
   userSchema: Option[StructType] = None,
   startColumn: Int = 0,
-  endColumn: Int = Int.MaxValue
+  endColumn: Int = Int.MaxValue,
+  timestampFormat: Option[String] = None
   )
   (@transient val sqlContext: SQLContext)
 extends BaseRelation with TableScan with PrunedScan {
@@ -99,7 +100,7 @@ extends BaseRelation with TableScan with PrunedScan {
       case _: DoubleType => numericValue
       case _: BooleanType => cell.getBooleanCellValue
       case _: DecimalType => bigDecimal
-      case _: TimestampType => Timestamp.valueOf(stringValue)
+      case _: TimestampType => parseTimestamp(stringValue)
       case _: DateType => new java.sql.Date(DateUtil.getJavaDate(numericValue).getTime)
       case _: StringType => stringValue
       case t => throw new RuntimeException(s"Unsupported cast from $cell to $t")
@@ -108,6 +109,19 @@ extends BaseRelation with TableScan with PrunedScan {
 
   private def rowsRdd: RDD[SheetRow] = {
     parallelize(sheet.rowIterator().asScala.toSeq)
+  }
+
+  private def parseTimestamp(stringValue: String, pattern: String): Timestamp = {
+    val format = new SimpleDateFormat(pattern)
+    val parsedDate = format.parse(stringValue)
+    new Timestamp(parsedDate.getTime)
+  }
+
+  private def parseTimestamp(stringValue: String): Timestamp = {
+    timestampFormat match {
+      case Some(pattern) => parseTimestamp(stringValue, pattern)
+      case None => Timestamp.valueOf(stringValue)
+    }
   }
 
   private def dataRows = sheet.rowIterator.asScala.drop(if (useHeader) 1 else 0)


### PR DESCRIPTION
Before this change, timestamps would only be parsed if they were in the default format `yyyy-[m]m-[d]d hh:mm:ss[.f...]`

Otherwise, an exception was thrown.

With this change, an optional "timestampFormat" parameter can be given with a different format string, e.g. `hh:mm:ss:SSS`

If no timestampFormat is given, then the behavior remains the same as before

