### PR TITLE
allow timestamp format to be specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ df.write
   .format("com.crealytics.spark.excel")
   .option("sheetName", "Daily")
   .option("useHeader", "true")
+  .option("timestampFormat", "HH:mm:ss") // Optional, default: yyyy-MM-dd HH:mm:ss.SSS
   .mode("overwrite")
   .save("Worktime2.xlsx")
 ```

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ val df = sqlContext.read
     .option("addColorColumns", "true") // Optional, default: false
     .option("startColumn", 0) // Optional, default: 0
     .option("endColumn", 99) // Optional, default: Int.MaxValue
+    .option("timestampFormat", "hh:mm:ss:SSS") // Optional, default: yyyy-mm-dd hh:mm:ss[.fffffffff]
     .schema(myCustomSchema) // Optional, default: Either inferred schema, or all columns are Strings
     .load("Worktime.xlsx")
 ```

--- a/src/main/scala/com/crealytics/spark/excel/DefaultSource.scala
+++ b/src/main/scala/com/crealytics/spark/excel/DefaultSource.scala
@@ -51,6 +51,7 @@ class DefaultSource
     val path = checkParameter(parameters, "path")
     val sheetName = parameters.getOrElse("sheetName", "Sheet1")
     val useHeader = checkParameter(parameters, "useHeader").toBoolean
+    val timestampFormat = parameters.getOrElse("timestampFormat", ExcelFileSaver.DEFAULT_TIMESTAMP_FORMAT)
     val filesystemPath = new Path(path)
     val fs = filesystemPath.getFileSystem(sqlContext.sparkContext.hadoopConfiguration)
     val doSave = if (fs.exists(filesystemPath)) {
@@ -73,7 +74,8 @@ class DefaultSource
         filesystemPath,
         data,
         sheetName = sheetName,
-        useHeader = useHeader
+        useHeader = useHeader,
+        timestampFormat = timestampFormat
       )
     }
 

--- a/src/main/scala/com/crealytics/spark/excel/DefaultSource.scala
+++ b/src/main/scala/com/crealytics/spark/excel/DefaultSource.scala
@@ -38,7 +38,8 @@ class DefaultSource
       inferSheetSchema = parameters.get("inferSchema").fold(false)(_.toBoolean),
       addColorColumns = parameters.get("addColorColumns").fold(false)(_.toBoolean),
       startColumn = parameters.get("startColumn").fold(0)(_.toInt),
-      endColumn = parameters.get("endColumn").fold(Int.MaxValue)(_.toInt)
+      endColumn = parameters.get("endColumn").fold(Int.MaxValue)(_.toInt),
+      timestampFormat = parameters.get("timestampFormat")
     )(sqlContext)
   }
 

--- a/src/main/scala/com/crealytics/spark/excel/ExcelRelation.scala
+++ b/src/main/scala/com/crealytics/spark/excel/ExcelRelation.scala
@@ -2,7 +2,7 @@ package com.crealytics.spark.excel
 
 import java.math.BigDecimal
 import java.sql.{Date, Timestamp}
-import java.text.NumberFormat
+import java.text.{NumberFormat, SimpleDateFormat}
 import java.util.Locale
 
 import org.apache.hadoop.fs.{FileSystem, Path}
@@ -25,7 +25,8 @@ case class ExcelRelation(
   addColorColumns: Boolean = true,
   userSchema: Option[StructType] = None,
   startColumn: Int = 0,
-  endColumn: Int = Int.MaxValue
+  endColumn: Int = Int.MaxValue,
+  timestampFormat: Option[String] = None
   )
   (@transient val sqlContext: SQLContext)
 extends BaseRelation with TableScan with PrunedScan {
@@ -99,7 +100,7 @@ extends BaseRelation with TableScan with PrunedScan {
       case _: DoubleType => numericValue
       case _: BooleanType => cell.getBooleanCellValue
       case _: DecimalType => bigDecimal
-      case _: TimestampType => Timestamp.valueOf(stringValue)
+      case _: TimestampType => parseTimestamp(stringValue)
       case _: DateType => new java.sql.Date(DateUtil.getJavaDate(numericValue).getTime)
       case _: StringType => stringValue
       case t => throw new RuntimeException(s"Unsupported cast from $cell to $t")
@@ -108,6 +109,19 @@ extends BaseRelation with TableScan with PrunedScan {
 
   private def rowsRdd: RDD[SheetRow] = {
     parallelize(sheet.rowIterator().asScala.toSeq)
+  }
+
+  private def parseTimestamp(stringValue: String, pattern: String): Timestamp = {
+    val format = new SimpleDateFormat(pattern)
+    val parsedDate = format.parse(stringValue)
+    new Timestamp(parsedDate.getTime)
+  }
+
+  private def parseTimestamp(stringValue: String): Timestamp = {
+    timestampFormat match {
+      case Some(pattern) => parseTimestamp(stringValue, pattern)
+      case None => Timestamp.valueOf(stringValue)
+    }
   }
 
   private def dataRows = sheet.rowIterator.asScala.drop(if (useHeader) 1 else 0)

--- a/src/main/scala/com/crealytics/spark/excel/ExcelRelation.scala
+++ b/src/main/scala/com/crealytics/spark/excel/ExcelRelation.scala
@@ -44,10 +44,11 @@ extends BaseRelation with TableScan with PrunedScan {
   override val schema: StructType = inferSchema
   val dataFormatter = new DataFormatter()
 
-  val timestampParser = if (timestampFormat.isDefined)
+  val timestampParser = if (timestampFormat.isDefined) {
     Some(new SimpleDateFormat(timestampFormat.get))
-  else
+  } else {
     None
+  }
 
   private def findSheet(workBook: Workbook, sheetName: Option[String]): Sheet = {
     sheetName.map { sn =>

--- a/src/test/scala/com/crealytics/spark/excel/IntegrationSuite.scala
+++ b/src/test/scala/com/crealytics/spark/excel/IntegrationSuite.scala
@@ -1,6 +1,7 @@
 package com.crealytics.spark.excel
 
 import java.io.File
+import java.sql.Timestamp
 
 import org.scalacheck.{Arbitrary, Gen, Shrink}
 import Arbitrary.{arbLong => _, arbString => _, _}
@@ -24,6 +25,7 @@ object IntegrationSuite {
     aLong: Long,
     aDouble: Double,
     aString: String,
+    aTimestamp: java.sql.Timestamp,
     aDate: java.sql.Date
   )
 
@@ -33,6 +35,12 @@ object IntegrationSuite {
     Gen
       .chooseNum[Long](0L, (new java.util.Date).getTime + 1000000)
       .map(new java.sql.Date(_))
+  )
+
+  implicit val arbitraryTimestamp = Arbitrary[java.sql.Timestamp](
+    Gen
+      .chooseNum[Long](0L, (new java.util.Date).getTime + 1000000)
+      .map(new java.sql.Timestamp(_))
   )
 
   // Unfortunately we're losing some precision when parsing Longs


### PR DESCRIPTION
Before this change, timestamps would only be parsed if they were in the default format `yyyy-[m]m-[d]d hh:mm:ss[.f...]`. Otherwise, an exception was thrown.

With this change, an optional _timestampFormat_ parameter can be given with a different format string, for example `hh:mm:ss:SSS`

If no _timestampFormat_ is given, then the behavior remains the same as before