### PR TITLE
write timestamp as number with format option and add format option fo…

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ val df = sqlContext.read
     .option("addColorColumns", "true") // Optional, default: false
     .option("startColumn", 0) // Optional, default: 0
     .option("endColumn", 99) // Optional, default: Int.MaxValue
-    .option("timestampFormat", "hh:mm:ss:SSS") // Optional, default: yyyy-mm-dd hh:mm:ss[.fffffffff]
+    .option("timestampFormat", "MM-dd-yyyy HH:mm:ss") // Optional, default: yyyy-mm-dd hh:mm:ss[.fffffffff]
     .schema(myCustomSchema) // Optional, default: Either inferred schema, or all columns are Strings
     .load("Worktime.xlsx")
 ```
@@ -58,7 +58,8 @@ df.write
   .format("com.crealytics.spark.excel")
   .option("sheetName", "Daily")
   .option("useHeader", "true")
-  .option("timestampFormat", "HH:mm:ss") // Optional, default: yyyy-MM-dd HH:mm:ss.SSS
+  .option("dateFormat", "yy-mmm-d") // Optional, default: yy-m-d h:mm
+  .option("timestampFormat", "mm-dd-yyyy hh:mm:ss") // Optional, default: yyyy-mm-dd hh:mm:ss.000
   .mode("overwrite")
   .save("Worktime2.xlsx")
 ```

--- a/src/main/scala/com/crealytics/spark/excel/DefaultSource.scala
+++ b/src/main/scala/com/crealytics/spark/excel/DefaultSource.scala
@@ -51,6 +51,7 @@ class DefaultSource
     val path = checkParameter(parameters, "path")
     val sheetName = parameters.getOrElse("sheetName", "Sheet1")
     val useHeader = checkParameter(parameters, "useHeader").toBoolean
+    val dateFormat = parameters.getOrElse("dateFormat", ExcelFileSaver.DEFAULT_DATE_FORMAT)
     val timestampFormat = parameters.getOrElse("timestampFormat", ExcelFileSaver.DEFAULT_TIMESTAMP_FORMAT)
     val filesystemPath = new Path(path)
     val fs = filesystemPath.getFileSystem(sqlContext.sparkContext.hadoopConfiguration)
@@ -75,6 +76,7 @@ class DefaultSource
         data,
         sheetName = sheetName,
         useHeader = useHeader,
+        dateFormat = dateFormat,
         timestampFormat = timestampFormat
       )
     }


### PR DESCRIPTION
I had second thoughts about saving Timestamps as strings. I think it is more useful to save them as numbers so that they can be used in Excel calculations.

This pull request does the following...
- Timestamps saved to Excel as numbers with optional formatting string. Default format is `yyyy-mm-dd hh:mm:ss.000`
- Added optional formatting string for dates. Default is unchanged as `yy-m-d h:mm`

One potentially confusing thing is that when reading a file, `timestampFormat `is in Java SimpleDateFormat style for parsing. 
But when writing a file, `dateFormat `and `timestampFormat `are in the Excel style for display formatting. Maybe we should add a note about this to README.md.

With this change, it is still possible to save the Timestamp column and reload it as the same type, provided the same formatting is used in both save and read. No changes to the tests were necessary.