### PR TITLE
Detect date formatted columns when inferring schema

### DIFF
--- a/src/main/scala/com/crealytics/spark/excel/ExcelRelation.scala
+++ b/src/main/scala/com/crealytics/spark/excel/ExcelRelation.scala
@@ -1,12 +1,10 @@
 package com.crealytics.spark.excel
 
 import java.math.BigDecimal
-import java.sql.{Date, Timestamp}
-import java.text.{NumberFormat, SimpleDateFormat}
-import java.util.Locale
+import java.sql.Timestamp
+import java.text.SimpleDateFormat
 
 import org.apache.hadoop.fs.{FileSystem, Path}
-import org.apache.poi.hssf.usermodel.HSSFDateUtil
 import org.apache.poi.ss.usermodel.{Cell, CellType, DataFormatter, DateUtil, Sheet, Workbook, WorkbookFactory, Row => SheetRow}
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql._
@@ -14,7 +12,6 @@ import org.apache.spark.sql.sources._
 import org.apache.spark.sql.types._
 
 import scala.collection.JavaConverters._
-import scala.util.Try
 
 case class ExcelRelation(
   location: String,
@@ -53,8 +50,8 @@ extends BaseRelation with TableScan with PrunedScan {
   private def findSheet(workBook: Workbook, sheetName: Option[String]): Sheet = {
     sheetName.map { sn =>
       Option(workBook.getSheet(sn)).getOrElse(
-          throw new IllegalArgumentException(s"Unknown sheet $sn")
-        )
+        throw new IllegalArgumentException(s"Unknown sheet $sn")
+      )
     }.getOrElse(workBook.sheetIterator.next)
   }
   override def buildScan: RDD[Row] = buildScan(schema.map(_.name).toArray)
@@ -90,7 +87,8 @@ extends BaseRelation with TableScan with PrunedScan {
   }
 
   private def castTo(cell: Cell, castType: DataType): Any = {
-    if (cell.getCellTypeEnum == CellType.BLANK) {
+    val cellType = cell.getCellTypeEnum
+    if (cellType == CellType.BLANK) {
       return null
     }
     val dataFormatter = new DataFormatter()
@@ -106,7 +104,10 @@ extends BaseRelation with TableScan with PrunedScan {
       case _: DoubleType => numericValue
       case _: BooleanType => cell.getBooleanCellValue
       case _: DecimalType => bigDecimal
-      case _: TimestampType => parseTimestamp(stringValue)
+      case _: TimestampType => cellType match {
+        case CellType.NUMERIC => new Timestamp(DateUtil.getJavaDate(numericValue).getTime)
+        case _ => parseTimestamp(stringValue)
+      }
       case _: DateType => new java.sql.Date(DateUtil.getJavaDate(numericValue).getTime)
       case _: StringType => stringValue
       case t => throw new RuntimeException(s"Unsupported cast from $cell to $t")
@@ -124,6 +125,18 @@ extends BaseRelation with TableScan with PrunedScan {
     }
   }
 
+  private def getSparkType(cell: Option[Cell]): DataType = {
+    cell match {
+      case Some(c) => c.getCellType match {
+        case Cell.CELL_TYPE_STRING => StringType
+        case Cell.CELL_TYPE_BOOLEAN => BooleanType
+        case Cell.CELL_TYPE_NUMERIC => if (DateUtil.isCellDateFormatted(c)) TimestampType else DoubleType
+        case Cell.CELL_TYPE_BLANK => NullType
+      }
+      case None => NullType
+    }
+  }
+
   private def dataRows = sheet.rowIterator.asScala.drop(if (useHeader) 1 else 0)
   private def parallelize[T: scala.reflect.ClassTag](seq: Seq[T]): RDD[T] = sqlContext.sparkContext.parallelize(seq)
   private def inferSchema: StructType =
@@ -134,9 +147,7 @@ extends BaseRelation with TableScan with PrunedScan {
       }
       val baseSchema = if (this.inferSheetSchema) {
         val stringsAndCellTypes = dataRows.map { row =>
-          row.eachCellIterator(startColumn, endColumn).map { cell =>
-            cell.fold(Cell.CELL_TYPE_BLANK)(_.getCellType)
-          }.toVector
+          row.eachCellIterator(startColumn, endColumn).map { cell => getSparkType(cell) }.toVector
         }.toVector
         InferSchema(parallelize(stringsAndCellTypes), header.toArray)
       } else {


### PR DESCRIPTION
Currently, spark-excel does not try to infer the type of date/time columns.

With this change, if the column is formatted with date and/or time portions in Excel, then spark-excel will infer the column type as a `Timestamp`. 
Inferring as `Timestamp` is more useful than inferring it as a `Date `because the spark `java.sql.Date` type hides any time component that might be present (hours, minutes, seconds, milliseconds).
The check for data/time formatting is done using the POI function.. `DateUtil.isCellDateFormatted`.

This PR also includes the change discussed [here](https://github.com/crealytics/spark-excel/pull/27).