### PR TITLE
#38 excerptSize option

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ val df = sqlContext.read
     .option("endColumn", 99) // Optional, default: Int.MaxValue
     .option("timestampFormat", "MM-dd-yyyy HH:mm:ss") // Optional, default: yyyy-mm-dd hh:mm:ss[.fffffffff]
     .option("maxRowsInMemory", 20) // Optional, default None. If set, uses a streaming reader which can help with big files
+    .option("excerptSize", 10) // Optional, default: 10. If set and if schema inferred, number of rows to infer schema from
     .schema(myCustomSchema) // Optional, default: Either inferred schema, or all columns are Strings
     .load("Worktime.xlsx")
 ```

--- a/src/main/scala/com/crealytics/spark/excel/DefaultSource.scala
+++ b/src/main/scala/com/crealytics/spark/excel/DefaultSource.scala
@@ -32,7 +32,8 @@ class DefaultSource extends RelationProvider with SchemaRelationProvider with Cr
       startColumn = parameters.get("startColumn").fold(0)(_.toInt),
       endColumn = parameters.get("endColumn").fold(Int.MaxValue)(_.toInt),
       timestampFormat = parameters.get("timestampFormat"),
-      maxRowsInMemory = parameters.get("maxRowsInMemory").map(_.toInt)
+      maxRowsInMemory = parameters.get("maxRowsInMemory").map(_.toInt),
+      excerptSize = parameters.get("excerptSize").fold(10)(_.toInt)
     )(sqlContext)
   }
 


### PR DESCRIPTION
This is the fix for #38 
I have made `excerptSize` a read option with a default of `10`
Also made parsing a bit more permissive so that if `excerptSize` is too small to catch a non-numeric in a mostly numeric column, the numeric value will be set to NaN instead of throwing an exception.