### PR TITLE
shade dependency on jackson

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -37,6 +37,10 @@ libraryDependencies ++= Seq(
   "org.scalamock" %% "scalamock-scalatest-support" % "3.5.0" % Test
 )
 
+assemblyShadeRules in assembly := Seq(
+  ShadeRule.rename("com.fasterxml.jackson.**" -> "shadeio.@1").inAll
+)
+
 fork in Test := true
 parallelExecution in Test := false
 javaOptions ++= Seq("-Xms512M", "-Xmx2048M", "-XX:MaxPermSize=2048M", "-XX:+CMSClassUnloadingEnabled")


### PR DESCRIPTION
this avoids an incompatibility with the version of jackson packaged with spark
see comments in #19 