### PR TITLE
Support for reading/writing from/to directory

### DIFF
--- a/src/main/scala/com/crealytics/spark/excel/DefaultSource.scala
+++ b/src/main/scala/com/crealytics/spark/excel/DefaultSource.scala
@@ -23,6 +23,7 @@ class DefaultSource extends RelationProvider with SchemaRelationProvider with Cr
   ): ExcelRelation = {
     ExcelRelation(
       location = checkParameter(parameters, "path"),
+      readFromFile = parameters.get("readFromFile"),
       sheetName = parameters.get("sheetName"),
       useHeader = checkParameter(parameters, "useHeader").toBoolean,
       treatEmptyValuesAsNulls = parameters.get("treatEmptyValuesAsNulls").fold(true)(_.toBoolean),
@@ -44,6 +45,7 @@ class DefaultSource extends RelationProvider with SchemaRelationProvider with Cr
     data: DataFrame
   ): BaseRelation = {
     val path = checkParameter(parameters, "path")
+    val writeToFile = parameters.get("writeToFile")
     val sheetName = parameters.getOrElse("sheetName", "Sheet1")
     val useHeader = checkParameter(parameters, "useHeader").toBoolean
     val dateFormat = parameters.getOrElse("dateFormat", ExcelFileSaver.DEFAULT_DATE_FORMAT)
@@ -68,6 +70,7 @@ class DefaultSource extends RelationProvider with SchemaRelationProvider with Cr
       // Only save data when the save mode is not ignore.
       (new ExcelFileSaver(fs)).save(
         filesystemPath,
+        writeToFile,
         data,
         sheetName = sheetName,
         useHeader = useHeader,

--- a/src/main/scala/com/crealytics/spark/excel/ExcelRelation.scala
+++ b/src/main/scala/com/crealytics/spark/excel/ExcelRelation.scala
@@ -26,6 +26,7 @@ import scala.util.{Failure, Success, Try}
 
 case class ExcelRelation(
   location: String,
+  readFromFile: Option[String],
   sheetName: Option[String],
   useHeader: Boolean,
   treatEmptyValuesAsNulls: Boolean,
@@ -42,7 +43,7 @@ case class ExcelRelation(
     with TableScan
     with PrunedScan {
 
-  private val path = new Path(location)
+  private val path = readFromFile.map(new Path(location, _)).getOrElse(new Path(location))
 
   def extractCells(row: org.apache.poi.ss.usermodel.Row): Vector[Option[Cell]] =
     row.eachCellIterator(startColumn, endColumn).to[Vector]

--- a/src/test/scala/com/crealytics/spark/excel/IntegrationSuite.scala
+++ b/src/test/scala/com/crealytics/spark/excel/IntegrationSuite.scala
@@ -1,16 +1,17 @@
 package com.crealytics.spark.excel
 
 import java.io.File
+import java.nio.file.Files
 import java.sql.Timestamp
 
 import org.scalacheck.{Arbitrary, Gen, Shrink}
-import Arbitrary.{arbLong => _, arbString => _, arbBigDecimal => _, _}
+import Arbitrary.{arbBigDecimal => _, arbLong => _, arbString => _, _}
 import org.scalacheck.ScalacheckShapeless._
-import org.scalatest.FunSpec
+import org.scalatest.{FunSpec, Matchers}
 import org.scalatest.prop.PropertyChecks
 import com.holdenkarau.spark.testing.DataFrameSuiteBase
 import org.apache.hadoop.fs.Path
-import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.{DataFrame, Row}
 import org.apache.spark.sql.catalyst.ScalaReflection
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.functions.lit
@@ -99,7 +100,7 @@ object IntegrationSuite {
 
 }
 
-class IntegrationSuite extends FunSpec with PropertyChecks with DataFrameSuiteBase {
+class IntegrationSuite extends FunSpec with PropertyChecks with DataFrameSuiteBase with Matchers {
 
   import IntegrationSuite._
 
@@ -195,6 +196,42 @@ class IntegrationSuite extends FunSpec with PropertyChecks with DataFrameSuiteBa
         }
       }
 
+      it("writes specified file inside path and reads back") {
+        val dir = Files.createTempDirectory("spark_excel_test")
+        val dirName = dir.toString
+        val fileName = "spark_excel_test.xlsx"
+
+        val df =
+          Seq((1, "1", "2", "3"), (2, "4", "5", "6"), (3, "7", "8", "9")).toDF("id", "column1", "column2", "column3")
+
+        df.write
+          .format(PackageName)
+          .option("sheetName", sheetName)
+          .option("useHeader", "true")
+          .option("writeToFile", fileName)
+          .mode("overwrite")
+          .save(dirName)
+
+        val result = spark.read
+          .format(PackageName)
+          .option("sheetName", sheetName)
+          .option("useHeader", "true")
+          .option("readFromFile", fileName)
+          .load(dirName)
+          .cache()
+
+        result.show()
+
+        result.schema.fields.map(_.name) should contain theSameElementsAs
+          Array("id", "column1", "column2", "column3")
+        result.collect() should contain theSameElementsAs Array(
+          Row("1", "1", "2", "3"),
+          Row("2", "4", "5", "6"),
+          Row("3", "7", "8", "9")
+        )
+
+        new File(dir.toFile, "_SUCCESS").exists() shouldBe true
+      }
     }
   }
   runTests(maxRowsInMemory = None)


### PR DESCRIPTION
Support for writing/reading files, when path specified to load/save methods is a directory.

Introduced new parameters:
- writeToFile - optional string parameter for writer, not set by default. Allows to specify filename to write excel file inside "path" directory. Also causes writer to create empty "_SUCCESS" flag inside "path".
- readFromFile - optional string parameter for reader, not set by default. Allows to specify filename to read excel file inside "path" directory.