### PR TITLE
Support for writing/reading files with legal disclaimer

### DIFF
--- a/src/main/scala/com/crealytics/spark/excel/DefaultSource.scala
+++ b/src/main/scala/com/crealytics/spark/excel/DefaultSource.scala
@@ -33,7 +33,8 @@ class DefaultSource extends RelationProvider with SchemaRelationProvider with Cr
       endColumn = parameters.get("endColumn").fold(Int.MaxValue)(_.toInt),
       timestampFormat = parameters.get("timestampFormat"),
       maxRowsInMemory = parameters.get("maxRowsInMemory").map(_.toInt),
-      excerptSize = parameters.get("excerptSize").fold(10)(_.toInt)
+      excerptSize = parameters.get("excerptSize").fold(10)(_.toInt),
+      skipFirstRows = parameters.get("skipFirstRows").map(_.toInt)
     )(sqlContext)
   }
 
@@ -48,6 +49,7 @@ class DefaultSource extends RelationProvider with SchemaRelationProvider with Cr
     val useHeader = checkParameter(parameters, "useHeader").toBoolean
     val dateFormat = parameters.getOrElse("dateFormat", ExcelFileSaver.DEFAULT_DATE_FORMAT)
     val timestampFormat = parameters.getOrElse("timestampFormat", ExcelFileSaver.DEFAULT_TIMESTAMP_FORMAT)
+    val legalDisclaimer = parameters.get("legalDisclaimer")
     val filesystemPath = new Path(path)
     val fs = filesystemPath.getFileSystem(sqlContext.sparkContext.hadoopConfiguration)
     val doSave = if (fs.exists(filesystemPath)) {
@@ -72,7 +74,8 @@ class DefaultSource extends RelationProvider with SchemaRelationProvider with Cr
         sheetName = sheetName,
         useHeader = useHeader,
         dateFormat = dateFormat,
-        timestampFormat = timestampFormat
+        timestampFormat = timestampFormat,
+        legalDisclaimer = legalDisclaimer
       )
     }
 

--- a/src/main/scala/com/crealytics/spark/excel/ExcelFileSaver.scala
+++ b/src/main/scala/com/crealytics/spark/excel/ExcelFileSaver.scala
@@ -24,8 +24,10 @@ class ExcelFileSaver(fs: FileSystem) {
     sheetName: String = DEFAULT_SHEET_NAME,
     useHeader: Boolean = true,
     dateFormat: String = DEFAULT_DATE_FORMAT,
-    timestampFormat: String = DEFAULT_TIMESTAMP_FORMAT
+    timestampFormat: String = DEFAULT_TIMESTAMP_FORMAT,
+    legalDisclaimer: Option[String]
   ): Unit = {
+    val legalDisclaimerRow = legalDisclaimer.map(s => Row(Cell(s))).toList
     val headerRow = Row(dataFrame.schema.fields.map(f => Cell(f.name)))
     val dataRows = dataFrame
       .toLocalIterator()
@@ -34,7 +36,7 @@ class ExcelFileSaver(fs: FileSystem) {
         Row(row.toSeq.map(toCell(_, dateFormat, timestampFormat)))
       }
       .toList
-    val rows = if (useHeader) headerRow :: dataRows else dataRows
+    val rows = legalDisclaimerRow ++ (if (useHeader) headerRow :: dataRows else dataRows)
     val workbook = Sheet(name = sheetName, rows = rows).convertAsXlsx
     val outputStream = fs.create(location)
     workbook.write(outputStream)

--- a/src/test/scala/com/crealytics/spark/excel/IntegrationSuite.scala
+++ b/src/test/scala/com/crealytics/spark/excel/IntegrationSuite.scala
@@ -199,11 +199,8 @@ class IntegrationSuite extends FunSpec with PropertyChecks with DataFrameSuiteBa
       it("writes data with legal disclaimer") {
         val fileName = File.createTempFile("spark_excel_test_", ".xlsx").getAbsolutePath
 
-        val df = Seq(
-          (1, "1", "2", "3"),
-          (2, "4", "5", "6"),
-          (3, "7", "8", "9")
-        ).toDF("id", "column1", "column2", "column3")
+        val df =
+          Seq((1, "1", "2", "3"), (2, "4", "5", "6"), (3, "7", "8", "9")).toDF("id", "column1", "column2", "column3")
 
         df.write
           .format(PackageName)
@@ -227,9 +224,7 @@ class IntegrationSuite extends FunSpec with PropertyChecks with DataFrameSuiteBa
         val legalDisclaimerResult = firstRowReader.load(fileName).limit(1).cache()
         legalDisclaimerResult.show()
 
-        legalDisclaimerResult.collect() should contain theSameElementsAs Array(
-          Row("All rights reserved")
-        )
+        legalDisclaimerResult.collect() should contain theSameElementsAs Array(Row("All rights reserved"))
 
         val dataResult = dataReader.load(fileName).cache()
         dataResult.show()


### PR DESCRIPTION
Support for writing/reading files with legal disclaimer (like "Confidential. All rights reserved (c) Company Name") in first row.

Introduced new parameters:
- legalDisclaimer - optional string parameter for writer, not set by default. Allows to write arbitrary string in the first cell of the first row of workbook.
- skipFirstRows - optional integer parameter for reader, not set by default. Allows to read data from files with arbitrary strings in first N rows (= skip this rows).