### PR TITLE
add Float type in toCell

### DIFF
--- a/src/main/scala/com/crealytics/spark/excel/ExcelFileSaver.scala
+++ b/src/main/scala/com/crealytics/spark/excel/ExcelFileSaver.scala
@@ -46,7 +46,7 @@ class ExcelFileSaver(fs: FileSystem) {
     case t: java.sql.Timestamp => dateCell(t.getTime, timestampFormat)
     case d: java.sql.Date => dateCell(d.getTime, dateFormat)
     case s: String => Cell(s)
-    case f: Float => Cell(f)
+    case f: Float => Cell(f.toDouble)
     case d: Double => Cell(d)
     case b: Boolean => Cell(b)
     case b: Byte => Cell(b.toInt)

--- a/src/main/scala/com/crealytics/spark/excel/ExcelFileSaver.scala
+++ b/src/main/scala/com/crealytics/spark/excel/ExcelFileSaver.scala
@@ -46,6 +46,7 @@ class ExcelFileSaver(fs: FileSystem) {
     case t: java.sql.Timestamp => dateCell(t.getTime, timestampFormat)
     case d: java.sql.Date => dateCell(d.getTime, dateFormat)
     case s: String => Cell(s)
+    case f: Float => Cell(f)
     case d: Double => Cell(d)
     case b: Boolean => Cell(b)
     case b: Byte => Cell(b.toInt)

--- a/src/test/scala/com/crealytics/spark/excel/IntegrationSuite.scala
+++ b/src/test/scala/com/crealytics/spark/excel/IntegrationSuite.scala
@@ -1,19 +1,17 @@
 package com.crealytics.spark.excel
 
 import java.io.File
-import java.sql.Timestamp
 
-import org.scalacheck.{Arbitrary, Gen, Shrink}
-import Arbitrary.{arbLong => _, arbString => _, arbBigDecimal => _, _}
-import org.scalacheck.ScalacheckShapeless._
-import org.scalatest.FunSpec
-import org.scalatest.prop.PropertyChecks
 import com.holdenkarau.spark.testing.DataFrameSuiteBase
-import org.apache.hadoop.fs.Path
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.catalyst.ScalaReflection
-import org.apache.spark.sql.types._
 import org.apache.spark.sql.functions.lit
+import org.apache.spark.sql.types._
+import org.scalacheck.Arbitrary.{ arbBigDecimal => _, arbLong => _, arbString => _, _ }
+import org.scalacheck.ScalacheckShapeless._
+import org.scalacheck.{ Arbitrary, Gen, Shrink }
+import org.scalatest.FunSpec
+import org.scalatest.prop.PropertyChecks
 
 object IntegrationSuite {
 
@@ -23,6 +21,7 @@ object IntegrationSuite {
     aShort: Short,
     anInt: Int,
     aLong: Long,
+    aFloat: Float,
     aDouble: Double,
     aBigDecimal: BigDecimal,
     aJavaBigDecimal: java.math.BigDecimal,


### PR DESCRIPTION
```
java.lang.RuntimeException: scala.MatchError: 0.0 (of class java.lang.Float)
at com.crealytics.spark.excel.ExcelFileSaver.toCell(ExcelFileSaver.scala:44)
...
```

Don't know why Float is left out. I encountered the above error using Spark 2.1.1 and spark-excel master.