### PR TITLE
preHeader support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,13 +2,13 @@ name := "spark-excel"
 
 organization := "com.crealytics"
 
-crossScalaVersions := Seq("2.11.11", "2.10.6")
+crossScalaVersions := Seq("2.11.12", "2.10.6")
 
 scalaVersion := crossScalaVersions.value.head
 
 spName := "crealytics/spark-excel"
 
-sparkVersion := "2.2.0"
+sparkVersion := "2.3.1"
 
 val testSparkVersion = settingKey[String]("The version of Spark to test against.")
 

--- a/build.sbt
+++ b/build.sbt
@@ -30,12 +30,12 @@ libraryDependencies ++= Seq(
 
 libraryDependencies ++= Seq(
   "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.8.8" % Test,
-  "org.scalatest" %% "scalatest" % "3.0.1" % Test,
-  "org.scalacheck" %% "scalacheck" % "1.13.4" % Test,
-  "com.github.alexarchambault" %% "scalacheck-shapeless_1.13" % "1.1.6" % Test,
+  "org.scalatest" %% "scalatest" % "3.0.5" % Test,
+  "org.scalacheck" %% "scalacheck" % "1.14.0" % Test,
+  "com.github.alexarchambault" %% "scalacheck-shapeless_1.13" % "1.1.8" % Test,
   "com.github.nightscape" % "spark-testing-base" % "c6ac5d3b0629440f5fe13cf8830fdb17535c8513" % Test,
 //  "com.holdenkarau" %% "spark-testing-base" % s"${testSparkVersion.value}_0.7.4" % Test,
-  "org.scalamock" %% "scalamock-scalatest-support" % "3.5.0" % Test
+  "org.scalamock" %% "scalamock-scalatest-support" % "3.6.0" % Test
 )
 
 assemblyShadeRules in assembly := Seq(ShadeRule.rename("com.fasterxml.jackson.**" -> "shadeio.@1").inAll)

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.1.0
+sbt.version=1.1.4

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -20,4 +20,4 @@ addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.0")
 
 addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.1-M1")
 
-addSbtPlugin("com.geirsson" % "sbt-scalafmt" % "1.4.0")
+addSbtPlugin("com.geirsson" % "sbt-scalafmt" % "1.5.1")

--- a/src/main/scala/com/crealytics/spark/excel/DefaultSource.scala
+++ b/src/main/scala/com/crealytics/spark/excel/DefaultSource.scala
@@ -33,7 +33,8 @@ class DefaultSource extends RelationProvider with SchemaRelationProvider with Cr
       endColumn = parameters.get("endColumn").fold(Int.MaxValue)(_.toInt),
       timestampFormat = parameters.get("timestampFormat"),
       maxRowsInMemory = parameters.get("maxRowsInMemory").map(_.toInt),
-      excerptSize = parameters.get("excerptSize").fold(10)(_.toInt)
+      excerptSize = parameters.get("excerptSize").fold(10)(_.toInt),
+      skipFirstRows = parameters.get("skipFirstRows").map(_.toInt)
     )(sqlContext)
   }
 
@@ -48,6 +49,7 @@ class DefaultSource extends RelationProvider with SchemaRelationProvider with Cr
     val useHeader = checkParameter(parameters, "useHeader").toBoolean
     val dateFormat = parameters.getOrElse("dateFormat", ExcelFileSaver.DEFAULT_DATE_FORMAT)
     val timestampFormat = parameters.getOrElse("timestampFormat", ExcelFileSaver.DEFAULT_TIMESTAMP_FORMAT)
+    val preHeader = parameters.get("preHeader")
     val filesystemPath = new Path(path)
     val fs = filesystemPath.getFileSystem(sqlContext.sparkContext.hadoopConfiguration)
     val doSave = if (fs.exists(filesystemPath)) {
@@ -72,7 +74,8 @@ class DefaultSource extends RelationProvider with SchemaRelationProvider with Cr
         sheetName = sheetName,
         useHeader = useHeader,
         dateFormat = dateFormat,
-        timestampFormat = timestampFormat
+        timestampFormat = timestampFormat,
+        preHeader = preHeader
       )
     }
 

--- a/src/main/scala/com/crealytics/spark/excel/ExcelFileSaver.scala
+++ b/src/main/scala/com/crealytics/spark/excel/ExcelFileSaver.scala
@@ -28,7 +28,7 @@ class ExcelFileSaver(fs: FileSystem) {
     timestampFormat: String = DEFAULT_TIMESTAMP_FORMAT,
     preHeader: Option[String]
   ): Unit = {
-    val preHeaderRow = preHeader.toList.flatMap(_.split("\\R", -1).map(s => Row(Cell(s))))
+    val preHeaderRow = preHeader.toList.flatMap(_.split("\\R", -1).map(s => Row(s.split("\t").map(Cell(_)))))
     val headerRow = Row(dataFrame.schema.fields.map(f => Cell(f.name)))
     val dataRows = dataFrame
       .toLocalIterator()


### PR DESCRIPTION
This is a slight change to https://github.com/crealytics/spark-excel/pull/58
The parameter for adding stuff above the actual headers is now called `preHeader` because it could contain other stuff like summaries, comments, ...
If `preHeader` contains line-breaks, these get transformed into new rows.
The tests are now also randomized via ScalaCheck (which immediately uncovered a problem with empty `preHeader = Some("")` leading to a `?` being written in some cases, a problem I chose to ignore for the time being).
@kholodilov could you have a look if there's any regressions or any improvements you'd like to add?