### PR TITLE
Allow numeric headers; Support #All dataAddress for xls

### DIFF
--- a/src/main/scala/com/crealytics/spark/excel/DataLocator.scala
+++ b/src/main/scala/com/crealytics/spark/excel/DataLocator.scala
@@ -12,6 +12,7 @@ import com.norbitltd.spoiwo.model.{
 }
 import HasIndex._
 import com.crealytics.spark.excel.Utils.MapIncluding
+import org.apache.poi.hssf.usermodel.HSSFWorkbook
 import org.apache.poi.ss.SpreadsheetVersion
 import org.apache.poi.ss.usermodel.{Cell, Row, Sheet, Workbook}
 import org.apache.poi.ss.util.{AreaReference, CellRangeAddress, CellReference}
@@ -152,8 +153,10 @@ class TableDataLocator(
   val timestampFormat: Option[String] = None
 ) extends AreaDataLocator {
   override def readFrom(workbook: Workbook): Iterator[Seq[Cell]] = {
-    val xwb = workbook.asInstanceOf[XSSFWorkbook]
-    readFromSheet(workbook, Some(xwb.getTable(tableName).getSheetName))
+    workbook match {
+      case xss: XSSFWorkbook => readFromSheet(workbook, Some(xss.getTable(tableName).getSheetName))
+      case hss: HSSFWorkbook => hss.getSheet(tableName).iterator().asScala.map(_.iterator().asScala.toList)
+    }
   }
   override def toSheet(
     header: Option[Seq[String]],

--- a/src/main/scala/com/crealytics/spark/excel/ExcelRelation.scala
+++ b/src/main/scala/com/crealytics/spark/excel/ExcelRelation.scala
@@ -1,5 +1,6 @@
 package com.crealytics.spark.excel
 
+import java.math.BigDecimal
 import java.sql.Timestamp
 import java.text.SimpleDateFormat
 
@@ -114,8 +115,12 @@ case class ExcelRelation(
       case CellType.STRING => cell.getStringCellValue
       case CellType.BOOLEAN => cell.getBooleanCellValue.toString
       case CellType.NUMERIC if DateUtil.isCellDateFormatted(cell) => cell.getDateCellValue.toString
-      case CellType.NUMERIC => cell.getNumericCellValue.toString
+      case CellType.NUMERIC => stripTrailingZeros(cell.getNumericCellValue)
     }
+  }
+
+  private def stripTrailingZeros(double: Double) = {
+    new BigDecimal(double).toString
   }
 
   private def parallelize[T : scala.reflect.ClassTag](seq: Seq[T]): RDD[T] = sqlContext.sparkContext.parallelize(seq)


### PR DESCRIPTION
Following issues were fixed:
1. Numeric values in header [issue](https://github.com/crealytics/spark-excel/issues/137).
2. dataAddress with suffix`#All` throws exception for xls file:

> shadeio.poi.hssf.usermodel.HSSFWorkbook cannot be cast to shadeio.poi.xssf.usermodel.XSSFWorkbook
> java.lang.ClassCastException: shadeio.poi.hssf.usermodel.HSSFWorkbook cannot be cast to shadeio.poi.xssf.usermodel.XSSFWorkbook
> 	at com.crealytics.spark.excel.TableDataLocator.readFrom(DataLocator.scala:155)
> 	at com.crealytics.spark.excel.ExcelRelation$$anonfun$excerpt$1.apply(ExcelRelation.scala:31)

A test case was added to reproduce behavior in point 2.