### PR TITLE
update commons-compress version to 1.19

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -27,7 +27,7 @@ shadedDeps ++= Seq(
   "org.apache.poi" ^ "poi" ^ "4.1.0",
   "org.apache.poi" ^ "poi-ooxml" ^ "4.1.0",
   "com.norbitltd" ^^ "spoiwo" ^ "1.6.0",
-  "org.apache.commons" ^ "commons-compress" ^ "1.18",
+  "org.apache.commons" ^ "commons-compress" ^ "1.19",
   "com.fasterxml.jackson.core" ^ "jackson-core" ^ "2.8.8",
 )
 


### PR DESCRIPTION
Current version 1.18 has a DoS bug that is fixed in 1.19
 https://commons.apache.org/proper/commons-compress/security-reports.html