### PR TITLE
#135: Shade on xlsx-streamer

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -20,11 +20,11 @@ resolvers ++= Seq("jitpack" at "https://jitpack.io")
 
 libraryDependencies ++= Seq(
   "org.slf4j" % "slf4j-api" % "1.7.30" % "provided",
-  "com.monitorjbl" % "xlsx-streamer" % "2.1.0"
+  "org.apache.poi" % "poi" % "4.1.0"
 ).map(_.excludeAll(ExclusionRule(organization = "stax")))
 
 shadedDeps ++= Seq(
-  "org.apache.poi" ^ "poi" ^ "4.1.0",
+  "com.monitorjbl" ^ "xlsx-streamer" ^ "2.1.0",
   "org.apache.poi" ^ "poi-ooxml" ^ "4.1.0",
   "com.norbitltd" ^^ "spoiwo" ^ "1.6.0",
   "org.apache.commons" ^ "commons-compress" ^ "1.19",
@@ -32,7 +32,7 @@ shadedDeps ++= Seq(
 )
 
 shadeRenames ++= Seq(
-  "org.apache.poi.**" -> "shadeio.poi.@1",
+  "com.monitorjbl.**" -> "shadeio.monitorjbl.@1",
   "com.norbitltd.spoiwo.**" -> "shadeio.spoiwo.@1",
   "com.fasterxml.jackson.**" -> "shadeio.jackson.@1",
   "org.apache.commons.compress.**" -> "shadeio.commons.compress.@1",

--- a/src/main/scala/com/crealytics/spark/excel/DefaultSource.scala
+++ b/src/main/scala/com/crealytics/spark/excel/DefaultSource.scala
@@ -10,6 +10,7 @@ import org.apache.spark.sql.{DataFrame, SQLContext, SaveMode}
 import scala.util.Try
 
 class DefaultSource extends RelationProvider with SchemaRelationProvider with CreatableRelationProvider {
+
   /**
     * Creates a new relation for retrieving data from an Excel file
     */


### PR DESCRIPTION
I accidentally closed previous [PR](https://github.com/crealytics/spark-excel/pull/168).
Issue #135

@nightscape
I tested it properly now by [publishing](https://oss.sonatype.org/#nexus-search;quick~com.github.enverosmanov) on remote repository.
```
resolvers +=
  "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots"

//libraryDependencies += "com.crealytics" %% "spark-excel" % "0.12.3"
libraryDependencies += "com.github.enverosmanov" %% "spark-excel" % "0.12.4-SNAPSHOT"
```