### PR TITLE
Rename 'useHeader' to 'header'

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ val spark: SparkSession = ???
 val df = spark.read
     .format("com.crealytics.spark.excel")
     .option("dataAddress", "'My Sheet'!B3:C35") // Optional, default: "A1"
-    .option("useHeader", "true") // Required
+    .option("header", "true") // Required
     .option("treatEmptyValuesAsNulls", "false") // Optional, default: true
     .option("inferSchema", "false") // Optional, default: false
     .option("addColorColumns", "true") // Optional, default: false
@@ -87,7 +87,7 @@ import com.crealytics.spark.excel._
 
 val spark: SparkSession = ???
 val df = spark.read.excel(
-    useHeader = true,  // Required
+    header = true,  // Required
     dataAddress = "'My Sheet'!B3:C35", // Optional, default: "A1"
     treatEmptyValuesAsNulls = false,  // Optional, default: true
     inferSchema = false,  // Optional, default: false
@@ -104,7 +104,7 @@ If the sheet name is unavailable, it is possible to pass in an index:
 
 ```scala
 val df = spark.read.excel(
-  useHeader = true,
+  header = true,
   dataAddress = "0!B3:C35"
 ).load("Worktime.xlsx")
 ```
@@ -116,7 +116,7 @@ val sheetNames = WorkbookReader( Map("path") -> "Worktime.xlsx"
                                , spark.sparkContext.hadoopConfiguration
                                ).sheetNames
 val df = spark.read.excel(
-  useHeader = true,
+  header = true,
   dataAddress = sheetNames(0)
 )
 ```
@@ -136,7 +136,7 @@ val spark: SparkSession = ???
 val df = spark.read
     .format("com.crealytics.spark.excel")
     .option("sheetName", "Info")
-    .option("useHeader", "true")
+    .option("header", "true")
     .schema(peopleSchema)
     .load("People.xlsx")
 ```
@@ -149,7 +149,7 @@ val df: DataFrame = ???
 df.write
   .format("com.crealytics.spark.excel")
   .option("dataAddress", "'My Sheet'!B3:C35")
-  .option("useHeader", "true")
+  .option("header", "true")
   .option("dateFormat", "yy-mmm-d") // Optional, default: yy-m-d h:mm
   .option("timestampFormat", "mm-dd-yyyy hh:mm:ss") // Optional, default: yyyy-mm-dd hh:mm:ss.000
   .mode("append") // Optional, default: overwrite.

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -8,7 +8,7 @@ addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0" excludeAll(
 
 addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.4.3")
 
-addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.6.2")
+addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.6.4")
 
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.10")
 

--- a/src/main/scala/com/crealytics/spark/excel/DefaultSource.scala
+++ b/src/main/scala/com/crealytics/spark/excel/DefaultSource.scala
@@ -28,7 +28,7 @@ class DefaultSource extends RelationProvider with SchemaRelationProvider with Cr
     val wbReader = WorkbookReader(parameters, sqlContext.sparkContext.hadoopConfiguration)
     val dataLocator = DataLocator(parameters)
     ExcelRelation(
-      useHeader = checkParameter(parameters, "useHeader").toBoolean,
+      header = checkParameter(parameters, "header").toBoolean,
       treatEmptyValuesAsNulls = parameters.get("treatEmptyValuesAsNulls").fold(false)(_.toBoolean),
       userSchema = Option(schema),
       inferSheetSchema = parameters.get("inferSchema").fold(false)(_.toBoolean),
@@ -47,7 +47,7 @@ class DefaultSource extends RelationProvider with SchemaRelationProvider with Cr
     data: DataFrame
   ): BaseRelation = {
     val path = checkParameter(parameters, "path")
-    val useHeader = checkParameter(parameters, "useHeader").toBoolean
+    val header = checkParameter(parameters, "header").toBoolean
     val filesystemPath = new Path(path)
     val fs = filesystemPath.getFileSystem(sqlContext.sparkContext.hadoopConfiguration)
     new ExcelFileSaver(
@@ -55,7 +55,7 @@ class DefaultSource extends RelationProvider with SchemaRelationProvider with Cr
       filesystemPath,
       data,
       saveMode = mode,
-      useHeader = useHeader,
+      header = header,
       dataLocator = DataLocator(parameters)
     ).save()
 

--- a/src/main/scala/com/crealytics/spark/excel/ExcelFileSaver.scala
+++ b/src/main/scala/com/crealytics/spark/excel/ExcelFileSaver.scala
@@ -24,11 +24,11 @@ class ExcelFileSaver(
   dataFrame: DataFrame,
   saveMode: SaveMode,
   dataLocator: DataLocator,
-  useHeader: Boolean = true
+  header: Boolean = true
 ) {
   def save(): Unit = {
     def sheet(workbook: XSSFWorkbook) = {
-      val headerRow = if (useHeader) Some(dataFrame.schema.fields.map(_.name).toSeq) else None
+      val headerRow = if (header) Some(dataFrame.schema.fields.map(_.name).toSeq) else None
       val dataRows = dataFrame
         .toLocalIterator()
         .asScala

--- a/src/main/scala/com/crealytics/spark/excel/ExcelRelation.scala
+++ b/src/main/scala/com/crealytics/spark/excel/ExcelRelation.scala
@@ -13,7 +13,7 @@ import scala.util.Try
 
 case class ExcelRelation(
   dataLocator: DataLocator,
-  useHeader: Boolean,
+  header: Boolean,
   treatEmptyValuesAsNulls: Boolean,
   inferSheetSchema: Boolean,
   addColorColumns: Boolean = true,
@@ -62,7 +62,7 @@ case class ExcelRelation(
     val lookups = requiredColumns.map(columnExtractor).toSeq
     workbookReader.withWorkbook { workbook =>
       val allDataIterator = dataLocator.readFrom(workbook)
-      val iter = if (useHeader) allDataIterator.drop(1) else allDataIterator
+      val iter = if (header) allDataIterator.drop(1) else allDataIterator
       val rows: Iterator[Seq[Any]] = iter
         .flatMap(
           row =>
@@ -122,7 +122,7 @@ case class ExcelRelation(
 
       def colName(cell: Cell) = cell.getStringCellValue
 
-      val colNames = if (useHeader) {
+      val colNames = if (header) {
         val headerNames = headerCells.map(colName)
         val duplicates = {
           val nonNullHeaderNames = headerNames.filter(_ != null)

--- a/src/main/scala/com/crealytics/spark/excel/package.scala
+++ b/src/main/scala/com/crealytics/spark/excel/package.scala
@@ -54,7 +54,7 @@ package object excel {
 
   implicit class ExcelDataFrameReader(val dataFrameReader: DataFrameReader) extends AnyVal {
     def excel(
-      useHeader: Boolean = true,
+      header: Boolean = true,
       treatEmptyValuesAsNulls: Boolean = false,
       inferSchema: Boolean = false,
       addColorColumns: Boolean = false,
@@ -65,7 +65,7 @@ package object excel {
       workbookPassword: String = null
     ): DataFrameReader = {
       Map(
-        "useHeader" -> useHeader,
+        "header" -> header,
         "treatEmptyValuesAsNulls" -> treatEmptyValuesAsNulls,
         "inferSchema" -> inferSchema,
         "addColorColumns" -> addColorColumns,
@@ -86,7 +86,7 @@ package object excel {
 
   implicit class ExcelDataFrameWriter[T](val dataFrameWriter: DataFrameWriter[T]) extends AnyVal {
     def excel(
-      useHeader: Boolean = true,
+      header: Boolean = true,
       dataAddress: String = null,
       preHeader: String = null,
       dateFormat: String = null,
@@ -94,7 +94,7 @@ package object excel {
       workbookPassword: String = null
     ): DataFrameWriter[T] = {
       Map(
-        "useHeader" -> useHeader,
+        "header" -> header,
         "dataAddress" -> dataAddress,
         "dateFormat" -> dateFormat,
         "timestampFormat" -> timestampFormat,

--- a/src/test/scala/com/crealytics/spark/excel/IntegrationSuite.scala
+++ b/src/test/scala/com/crealytics/spark/excel/IntegrationSuite.scala
@@ -71,11 +71,11 @@ class IntegrationSuite
       fileName: Option[String] = None,
       saveMode: SaveMode = SaveMode.Overwrite,
       dataAddress: Option[String] = None,
-      useHeader: Boolean = true
+      header: Boolean = true
     ): DataFrame = {
       val theFileName = fileName.getOrElse(File.createTempFile("spark_excel_test_", ".xlsx").getAbsolutePath)
 
-      val writer = df.write.excel(dataAddress = s"'$sheetName'!A1", useHeader = useHeader).mode(saveMode)
+      val writer = df.write.excel(dataAddress = s"'$sheetName'!A1", header = header).mode(saveMode)
       val configuredWriter =
         Map("dataAddress" -> dataAddress).foldLeft(writer) {
           case (wri, (key, Some(value))) => wri.option(key, value)
@@ -83,7 +83,7 @@ class IntegrationSuite
         }
       configuredWriter.save(theFileName)
 
-      val reader = spark.read.excel(dataAddress = s"'$sheetName'!A1", useHeader = useHeader)
+      val reader = spark.read.excel(dataAddress = s"'$sheetName'!A1", header = header)
       val configuredReader = Map(
         "maxRowsInMemory" -> maxRowsInMemory,
         "inferSchema" -> Some(schema.isEmpty),
@@ -193,7 +193,7 @@ class IntegrationSuite
             val inferred = writeThenRead(
               original,
               schema = None,
-              useHeader = false,
+              header = false,
               fileName = Some(fileName),
               dataAddress =
                 Some(s"'$sheetName'!${startCellAddress.formatAsString()}:${endCellAddress.formatAsString()}")
@@ -322,7 +322,7 @@ class IntegrationSuite
       )
     })
     val allData = spark.read
-      .excel(dataAddress = s"'$sheetName'!A1", useHeader = false, inferSchema = false)
+      .excel(dataAddress = s"'$sheetName'!A1", header = false, inferSchema = false)
       .load(fileName)
       .collect()
       .map(_.toSeq)


### PR DESCRIPTION
#211 
Main idea is to align parameters with Spark.

P.S. Also I updated "sbt-mima-plugin", because sbt couldn't find old one and I see the same problem on [CI](https://github.com/crealytics/spark-excel/actions).
P.P.S. It is breaking change so should be reflected on version. Because Spark silently skips unknown parameters.