### PR TITLE
Do not skip first line if header=false

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.6
+sbt.version=1.3.8

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.8
+sbt.version=1.3.6


### PR DESCRIPTION
### Problem:
1) Random test case [failure](https://github.com/crealytics/spark-excel/runs/463523382?check_suite_focus=true#step:4:253)
2) Missing first row when reading from file.

### Reason:
With parameters such as ("inferSchema" -> "true", "header" -> "false") first line is being ignored during schema detection. And if in a column first cell has a value but other cells are empty (nulls), the type of a column will be defined as NullType in spark-excel and nullable StringType in Spark.
```
// small example how null becomes StringType
val cellTypes = Seq(Seq(DataTypes.NullType))
InferSchema(parallelize(cellTypes)) // Array(StringType)
```
Later, spark-excel tries to read all rows one by one, but fails to read first row because it has a value different from nullable String (double, timestamp etc.). And this failure is being silently skipped due to empty [recover](https://github.com/crealytics/spark-excel/blob/master/src/main/scala/com/crealytics/spark/excel/ExcelRelation.scala#L74) block.

PS. ~I reverted sbt to 1.3.6~ because Intellij literally refuses to work with newer version due to the [bug](https://github.com/coursier/coursier/issues/1541).