### PR TITLE
Fix scala.Some in not valid type

### DIFF
--- a/src/main/scala/com/crealytics/spark/excel/DataColumn.scala
+++ b/src/main/scala/com/crealytics/spark/excel/DataColumn.scala
@@ -80,7 +80,8 @@ class HeaderDataColumn(
         stringValue.filterNot(_.isEmpty && treatEmptyValuesAsNulls)
       case t => throw new RuntimeException(s"Unsupported cast from $cell to $t")
     }
-    value.orElse(null)
+
+    value.orNull
   }
 
   private def stringToDouble(value: String): Double = {


### PR DESCRIPTION
Related issue #181. 
At the moment as the result of parsing of 1 cell spark-excel returns:
1) either value inside Some (for example `Some(3.14)`, `Some(true)`
2) or `null`.
That causes problems in Spark 3 (and for some users in Spark 2).
The proposed solution is to return:
1) either pure value (for example `3.14`, `true`)
2) or `null`.

To reproduce the issue now in master branch, you will need to change Spark in build.sbt:
```scala
sparkVersion := "3.0.0-preview2"
//sparkVersion := "2.4.4"
```
and run tests.