### PR TITLE
fix #258 include poi-shared-strings shaded dependency

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -29,6 +29,7 @@ shadedDeps ++= Seq(
   "org.apache.poi" ^ "poi-ooxml" ^ "4.1.2",
   "com.norbitltd" ^^ "spoiwo" ^ "1.7.0",
   "com.github.pjfanning" ^ "excel-streaming-reader" ^ "2.3.4",
+  "com.github.pjfanning" ^ "poi-shared-strings" ^ "1.0.4",
   "org.apache.commons" ^ "commons-compress" ^ "1.20",
   "com.fasterxml.jackson.core" ^ "jackson-core" ^ "2.8.8",
 )


### PR DESCRIPTION
This change successfully processes the sheet I was having trouble with and jar now contains the "shadeio.pjfanning.poi.xssf.streaming" package including TempFileSharedStringTable.