### PR TITLE
Upgrade to Spark 3.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ scalaVersion := crossScalaVersions.value.head
 
 spName := "crealytics/spark-excel"
 
-sparkVersion := "2.4.4"
+sparkVersion := "3.0.0"
 
 val testSparkVersion = settingKey[String]("The version of Spark to test against.")
 


### PR DESCRIPTION
We're upgrading to Spark 3.0 and we'd like to use the Excel reader as well :)

Ran the tests locally and they passed.