### PR TITLE
Remove leaking Jackson-Core

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,8 @@ jobs:
             spark: "3.0.0"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-      - uses: olafurpg/setup-scala@v5
+      - uses: actions/checkout@v2.3.4
+      - uses: olafurpg/setup-scala@v10
       - name: Test
         run: sbt -Dspark.testVersion=${{ matrix.spark  }} ++${{ matrix.scala }} test
       - name: Assembly

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2.3.4
       - name: GPG import
         run: openssl aes-256-cbc -pbkdf2 -k "${{ secrets.PGP_PASSPHRASE }}" -in private-key.pem.enc -out private-key.pem -d && gpg --import --no-tty --batch --yes private-key.pem
       - name: Publish

--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,10 @@ project/project/
 *.swp
 .idea
 *.log
+
+.metals/
+project/metals.sbt
+**/.bsp/
 **/.bloop/
+
 private-key.pem

--- a/build.sbt
+++ b/build.sbt
@@ -20,9 +20,8 @@ sparkComponents := Seq("core", "sql", "hive")
 
 resolvers ++= Seq("jitpack" at "https://jitpack.io")
 
-libraryDependencies ++= Seq(
-  "org.slf4j" % "slf4j-api" % "1.7.30" % "provided",
-).map(_.excludeAll(ExclusionRule(organization = "stax")))
+libraryDependencies ++= Seq("org.slf4j" % "slf4j-api" % "1.7.30" % "provided")
+  .map(_.excludeAll(ExclusionRule(organization = "stax")))
 
 shadedDeps ++= Seq(
   "org.apache.poi" ^ "poi" ^ "4.1.2",
@@ -30,23 +29,20 @@ shadedDeps ++= Seq(
   "com.norbitltd" ^^ "spoiwo" ^ "1.8.0",
   "com.github.pjfanning" ^ "excel-streaming-reader" ^ "2.3.5",
   "com.github.pjfanning" ^ "poi-shared-strings" ^ "1.0.4",
-  "org.apache.commons" ^ "commons-compress" ^ "1.20",
-  "com.fasterxml.jackson.core" ^ "jackson-core" ^ "2.11.3",
+  "org.apache.commons" ^ "commons-compress" ^ "1.20"
 )
 
 shadeRenames ++= Seq(
   "org.apache.poi.**" -> "shadeio.poi.@1",
   "com.norbitltd.spoiwo.**" -> "shadeio.spoiwo.@1",
   "com.github.pjfanning.**" -> "shadeio.pjfanning.@1",
-  "com.fasterxml.jackson.**" -> "shadeio.jackson.@1",
-  "org.apache.commons.compress.**" -> "shadeio.commons.compress.@1",
+  "org.apache.commons.compress.**" -> "shadeio.commons.compress.@1"
 )
 
 publishThinShadedJar
 
 libraryDependencies ++= Seq(
   "org.typelevel" %% "cats-core" % "2.0.0" % Test,
-  "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.11.3" % Test,
   "org.scalatest" %% "scalatest" % "3.2.3" % Test,
   "org.scalatestplus" %% "scalatestplus-scalacheck" % "3.1.0.0-RC2" % Test,
   "org.scalacheck" %% "scalacheck" % "1.15.1" % Test,
@@ -55,7 +51,6 @@ libraryDependencies ++= Seq(
   //  "com.holdenkarau" %% "spark-testing-base" % s"${testSparkVersion.value}_0.7.4" % Test,
   "org.scalamock" %% "scalamock-scalatest-support" % "3.6.0" % Test
 )
-
 
 fork in Test := true
 parallelExecution in Test := false
@@ -70,15 +65,13 @@ spIncludeMaven := true
 
 publishTo := sonatypePublishToBundle.value
 
-Global/useGpgPinentry := true
+Global / useGpgPinentry := true
 
 licenses += "Apache License, Version 2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0.html")
 
 homepage := Some(url("https://github.com/crealytics/spark-excel"))
 
-developers ++= List(
-  Developer("nightscape", "Martin Mauch", "@nightscape", url("https://github.com/nightscape"))
-)
+developers ++= List(Developer("nightscape", "Martin Mauch", "@nightscape", url("https://github.com/nightscape")))
 scmInfo := Some(ScmInfo(url("https://github.com/crealytics/spark-excel"), "git@github.com:crealytics/spark-excel.git"))
 
 // Skip tests during assembly

--- a/src/main/scala/com/crealytics/spark/excel/DefaultSource.scala
+++ b/src/main/scala/com/crealytics/spark/excel/DefaultSource.scala
@@ -1,24 +1,18 @@
 package com.crealytics.spark.excel
 
-import com.crealytics.spark.excel.Utils._
 import org.apache.hadoop.fs.Path
-import org.apache.poi.ss.util.{CellRangeAddress, CellReference}
 import org.apache.spark.sql.sources._
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.{DataFrame, SQLContext, SaveMode}
 
-import scala.util.Try
-
 class DefaultSource extends RelationProvider with SchemaRelationProvider with CreatableRelationProvider {
 
-  /**
-    * Creates a new relation for retrieving data from an Excel file
+  /** Creates a new relation for retrieving data from an Excel file
     */
   override def createRelation(sqlContext: SQLContext, parameters: Map[String, String]): ExcelRelation =
     createRelation(sqlContext, parameters, null)
 
-  /**
-    * Creates a new relation for retrieving data from an Excel file
+  /** Creates a new relation for retrieving data from an Excel file
     */
   override def createRelation(
     sqlContext: SQLContext,

--- a/src/main/scala/com/crealytics/spark/excel/ExcelFileSaver.scala
+++ b/src/main/scala/com/crealytics/spark/excel/ExcelFileSaver.scala
@@ -1,15 +1,12 @@
 package com.crealytics.spark.excel
 
-import java.io.BufferedOutputStream
-
-import com.crealytics.spark.excel.ExcelFileSaver.{DEFAULT_DATE_FORMAT, DEFAULT_SHEET_NAME, DEFAULT_TIMESTAMP_FORMAT}
 import com.norbitltd.spoiwo.model._
 import com.norbitltd.spoiwo.natures.xlsx.Model2XlsxConversions._
 import org.apache.hadoop.fs.{FSDataInputStream, FileSystem, Path}
-import org.apache.poi.ss.util.CellRangeAddress
 import org.apache.poi.xssf.usermodel.XSSFWorkbook
 import org.apache.spark.sql.{DataFrame, SaveMode}
 
+import java.io.BufferedOutputStream
 import scala.collection.JavaConverters._
 
 object ExcelFileSaver {

--- a/src/main/scala/com/crealytics/spark/excel/WorkbookReader.scala
+++ b/src/main/scala/com/crealytics/spark/excel/WorkbookReader.scala
@@ -17,11 +17,10 @@ trait WorkbookReader {
     res
   }
   def sheetNames: Seq[String] = {
-    withWorkbook(
-      workbook =>
-        for (sheetIx <- (0 until workbook.getNumberOfSheets())) yield {
-          workbook.getSheetAt(sheetIx).getSheetName()
-        }
+    withWorkbook(workbook =>
+      for (sheetIx <- (0 until workbook.getNumberOfSheets())) yield {
+        workbook.getSheetAt(sheetIx).getSheetName()
+      }
     )
   }
 }
@@ -47,8 +46,8 @@ class DefaultWorkbookReader(inputStreamProvider: => InputStream, workbookPasswor
     extends WorkbookReader {
   protected def openWorkbook(): Workbook =
     workbookPassword
-      .fold(WorkbookFactory.create(inputStreamProvider))(
-        password => WorkbookFactory.create(inputStreamProvider, password)
+      .fold(WorkbookFactory.create(inputStreamProvider))(password =>
+        WorkbookFactory.create(inputStreamProvider, password)
       )
 }
 

--- a/src/main/scala/com/crealytics/spark/excel/package.scala
+++ b/src/main/scala/com/crealytics/spark/excel/package.scala
@@ -76,12 +76,11 @@ package object excel {
         "maxRowsInMemory" -> maxRowsInMemory,
         "excerptSize" -> excerptSize,
         "workbookPassword" -> workbookPassword
-      ).foldLeft(dataFrameReader.format("com.crealytics.spark.excel")) {
-        case (dfReader, (key, value)) =>
-          value match {
-            case null => dfReader
-            case v => dfReader.option(key, v.toString)
-          }
+      ).foldLeft(dataFrameReader.format("com.crealytics.spark.excel")) { case (dfReader, (key, value)) =>
+        value match {
+          case null => dfReader
+          case v => dfReader.option(key, v.toString)
+        }
       }
     }
   }
@@ -101,12 +100,11 @@ package object excel {
         "dateFormat" -> dateFormat,
         "timestampFormat" -> timestampFormat,
         "preHeader" -> preHeader
-      ).foldLeft(dataFrameWriter.format("com.crealytics.spark.excel")) {
-        case (dfWriter, (key, value)) =>
-          value match {
-            case null => dfWriter
-            case v => dfWriter.option(key, v.toString)
-          }
+      ).foldLeft(dataFrameWriter.format("com.crealytics.spark.excel")) { case (dfWriter, (key, value)) =>
+        value match {
+          case null => dfWriter
+          case v => dfWriter.option(key, v.toString)
+        }
       }
     }
   }

--- a/src/test/scala/com/crealytics/spark/excel/DataLocatorSuite.scala
+++ b/src/test/scala/com/crealytics/spark/excel/DataLocatorSuite.scala
@@ -1,16 +1,14 @@
 package com.crealytics.spark.excel
-import com.crealytics.tags.WIP
-import com.norbitltd.spoiwo.model.{CellRange, Sheet, Workbook}
-import org.apache.poi.ss.SpreadsheetVersion
-import org.apache.poi.ss.util.AreaReference
-import org.apache.poi.xssf.usermodel.XSSFWorkbook
-import com.norbitltd.spoiwo.natures.xlsx.Model2XlsxConversions._
-import org.scalacheck.Gen
 
-import scala.collection.JavaConverters._
-import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+import com.norbitltd.spoiwo.model.Workbook
+import com.norbitltd.spoiwo.natures.xlsx.Model2XlsxConversions._
+import org.apache.poi.xssf.usermodel.XSSFWorkbook
+import org.scalacheck.Gen
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+
+import scala.collection.JavaConverters._
 
 class DataLocatorSuite extends AnyFunSpec with ScalaCheckPropertyChecks with Matchers with Generators {
   describe("with a table reference") {

--- a/src/test/scala/com/crealytics/spark/excel/Generators.scala
+++ b/src/test/scala/com/crealytics/spark/excel/Generators.scala
@@ -1,7 +1,4 @@
 package com.crealytics.spark.excel
-import java.sql.{Date, Timestamp}
-import java.time.{Instant, ZoneId, ZoneOffset}
-import java.time.temporal.ChronoUnit
 
 import org.scalacheck.Arbitrary.{arbBigDecimal => _, arbLong => _, arbString => _, _}
 import org.scalacheck.ScalacheckShapeless._
@@ -11,7 +8,11 @@ import org.apache.spark.sql.catalyst.ScalaReflection
 import org.apache.spark.sql.types.StructType
 import org.scalacheck.{Arbitrary, Gen}
 
+import java.sql.{Date, Timestamp}
+import java.time.temporal.ChronoUnit
+import java.time.{Instant, ZoneId, ZoneOffset}
 import scala.collection.JavaConverters._
+
 case class ExampleData(
   aBoolean: Boolean,
   aBooleanOption: Option[Boolean],
@@ -118,7 +119,7 @@ trait Generators {
     val columnsByIndex = columns.map(c => c.id -> Cell[String](value = c.name, index = c.id.toInt)).toMap
     sheet
       .withRows(sheet.rows.map {
-        case r if r.index.exists(_ == startCellAddress.getRow) =>
+        case r if r.index.contains(startCellAddress.getRow) =>
           val cellIndices = (r.cells.map(_.index.get) ++ columns.map(_.id.toInt)).toList.distinct.sorted
           r.withCells(cellIndices.map { ci =>
             columnsByIndex


### PR DESCRIPTION
### Problematique
The main problem this PR solves (besides failing builds 😉  ) is the dependency on `jackson-core` that should have been shaded, but by some reason weren't. And this bites really hard.
I haven't found any code that depends on the Jackson library, so I did dare to remove it completely. However, I could be wrong, and I'd happily learn more about the topic 🙂 .
Thanks in advance.

Summary of changes in this PR:
- drop jackson-core dependency;
- bump GH Actions versions;
- make formatter great again;
- tiny fixes (unused imports etc).