### PR TITLE
Support error type for formula cell

### DIFF
--- a/src/main/scala/com/crealytics/spark/excel/DataColumn.scala
+++ b/src/main/scala/com/crealytics/spark/excel/DataColumn.scala
@@ -67,6 +67,7 @@ class HeaderDataColumn(
             case CellType.NUMERIC => Option(cell.getNumericCellValue)
             case CellType.STRING =>
               parseNumber(Option(cell.getRichStringCellValue).map(_.getString))
+            case CellType.ERROR => Some(0.0)
           }
       }
     lazy val booleanValue = cell.getCellType match {

--- a/src/test/scala/com/crealytics/spark/excel/PlainNumberReadSuite.scala
+++ b/src/test/scala/com/crealytics/spark/excel/PlainNumberReadSuite.scala
@@ -23,14 +23,16 @@ object PlainNumberReadSuite {
     Row(12345678901d, "12345678901-123", "12/1/20"),
     Row(123456789012d, "123456789012", "0.01"),
     Row(-0.12345678901, "0.05", "0h 14m"),
-    Row(null, null, null)
+    Row(null, null, null),
+    Row(0.0, "abc.def", null)
   ).asJava
 
   val expectedExcelDataInferSchema: util.List[Row] = List(
     Row(1.2345678901e10, "12345678901-123", "12/1/20"),
     Row(1.23456789012e11, "1.23457E+11", "0.01"), // values are displayed in scientific notation and rounded up
     Row(-0.12345678901, "0.05", "0h 14m"),
-    Row(null, null, null)
+    Row(null, null, null),
+    Row(0.0, "abc.def", null)
   ).asJava
 
   val expectedNonInferredSchema = StructType(


### PR DESCRIPTION
When a cell has formula inside LibreOffice shows it empty, but spark-excel silently skips(!) these rows.

@waiyan1612 could you explain, please, why `PlainNumberReadSuite` expects to skip rows? See failed test cases.

