### PR TITLE
For Spark DataSource API V2, spark-excel jar depends on spark-version

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,14 +28,14 @@ You can link against this library in your program at the following coordinates:
 ```
 groupId: com.crealytics
 artifactId: spark-excel_2.12
-version: 0.14.0
+version: <spark-version>_0.14.0
 ```
 
 ### Scala 2.11
 ```
 groupId: com.crealytics
 artifactId: spark-excel_2.11
-version: 0.14.0
+version: <spark-version>_0.14.0
 ```
 
 ## Using with Spark shell
@@ -184,4 +184,6 @@ Currently the following address styles are supported:
 ## Building From Source
 This library is built with [SBT](http://www.scala-sbt.org/0.13/docs/Command-Line-Reference.html).
 To build a JAR file simply run `sbt assembly` from the project root.
+To build for a specific spark version, for example spark-2.4.1, run `sbt -Dspark.testVersion=2.4.1 assembly`,
+also from the project root.
 The build configuration includes support for Scala 2.12 and 2.11.

--- a/build.sbt
+++ b/build.sbt
@@ -12,6 +12,9 @@ val testSparkVersion = settingKey[String]("The version of Spark to test against.
 
 testSparkVersion := sys.props.get("spark.testVersion").getOrElse(sparkVersion.value)
 
+// For Spark DataSource API V2, spark-excel jar file depends on spark-version
+version := testSparkVersion.value + "_" + version.value
+
 resolvers ++= Seq("jitpack" at "https://jitpack.io")
 
 libraryDependencies ++= Seq("org.slf4j" % "slf4j-api" % "1.7.32" % "provided")


### PR DESCRIPTION
Overview: 
 
- By using Spark Data Source API V2, which changed its signature between 2.4.*, 3.0.0 and 3.1.x, made spark-excel jar depends on specific version of spark. This is similar to [spark-testing-base](https://mvnrepository.com/artifact/com.holdenkarau/spark-testing-base)
- Users can still self-assemble the spark-excel jar file for their specific spark environment.
 
Spark Excel, however, also needs to publish jars with spark versions, for users who choose to use pre-assembled jars in public Maven repositories.
 
Changes:
- Prefix spark-excel version with _spark-version_
- Minor update on the Readme.md