### PR TITLE
fix incorrect excel formats in writing

### DIFF
--- a/src/main/scala/com/crealytics/spark/v2/excel/ExcelGenerator.scala
+++ b/src/main/scala/com/crealytics/spark/v2/excel/ExcelGenerator.scala
@@ -26,7 +26,7 @@ import org.apache.hadoop.conf.Configuration
 class ExcelGenerator(val path: String, val dataSchema: StructType, val conf: Configuration, val options: ExcelOptions) {
   /* Prepare target Excel workbook, sheet and where to write to */
   private val wb: Workbook =
-    if (options.fileExtension.toLowerCase == "xlsx") new HSSFWorkbook() else new XSSFWorkbook()
+    if (options.fileExtension.toLowerCase == "xlsx") new XSSFWorkbook() else new HSSFWorkbook()
 
   private val (sheet, firstCol, firstRow) = {
     val dataAddress = ExcelHelper(options).parsedRangeAddress()


### PR DESCRIPTION
Hi @nightscape 
This PR to fix incorrect format from excel file extension option.
When [testing .xls and .xlsx limitations](https://github.com/crealytics/spark-excel/wiki/Examples:-Resource-Usage-and-How-Big-Spark-Excel-Can-Handle%3F), I noticed this bug. This bug is in v2/excel only.
Sincerely,