### PR TITLE
Fix build by upgrading apache.poi to 5.1 and explicitely adding ooxml providers

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -21,8 +21,8 @@ libraryDependencies ++= Seq("org.slf4j" % "slf4j-api" % "1.7.32" % "provided")
   .map(_.excludeAll(ExclusionRule(organization = "stax")))
 
 shadedDeps ++= Seq(
-  "org.apache.poi" ^ "poi" ^ "5.0.0",
-  "org.apache.poi" ^ "poi-ooxml" ^ "5.0.0",
+  "org.apache.poi" ^ "poi" ^ "5.1.0",
+  "org.apache.poi" ^ "poi-ooxml" ^ "5.1.0",
   "com.norbitltd" ^^ "spoiwo" ^ "2.0.0",
   "com.github.pjfanning" ^ "excel-streaming-reader" ^ "3.2.3",
   "com.github.pjfanning" ^ "poi-shared-strings" ^ "2.2.3",

--- a/src/main/scala/com/crealytics/spark/excel/WorkbookReader.scala
+++ b/src/main/scala/com/crealytics/spark/excel/WorkbookReader.scala
@@ -7,6 +7,8 @@ import com.github.pjfanning.xlsx.StreamingReader
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileSystem, Path}
 import org.apache.poi.ss.usermodel.{Workbook, WorkbookFactory}
+import org.apache.poi.hssf.usermodel.HSSFWorkbookFactory
+import org.apache.poi.xssf.usermodel.XSSFWorkbookFactory
 
 trait WorkbookReader {
   protected def openWorkbook(): Workbook
@@ -29,6 +31,9 @@ object WorkbookReader {
   val WithLocationMaxRowsInMemoryAndPassword =
     MapIncluding(Seq("path"), optionally = Seq("maxRowsInMemory", "workbookPassword"))
 
+  WorkbookFactory.addProvider(new HSSFWorkbookFactory)
+  WorkbookFactory.addProvider(new XSSFWorkbookFactory)
+
   def apply(parameters: Map[String, String], hadoopConfiguration: Configuration): WorkbookReader = {
     def readFromHadoop(location: String) = {
       val path = new Path(location)
@@ -44,6 +49,7 @@ object WorkbookReader {
 }
 class DefaultWorkbookReader(inputStreamProvider: => InputStream, workbookPassword: Option[String])
     extends WorkbookReader {
+
   protected def openWorkbook(): Workbook =
     workbookPassword
       .fold(WorkbookFactory.create(inputStreamProvider))(password =>


### PR DESCRIPTION
Hey crealytics/spark-excel team,

thank you for upgrading to poi version 5. It resolves our issues with reading large excel files in spark. Unfortunately, in the current version of your jar shadeio.poi seems to be missing. With the upgrade to poi version 5.1 and the small addition to initialization in the code the jar built from sources works like a charm for us. Would be great if we could get this to mainline so everybody profits.

Best,

Clemens