### PR TITLE
fix for https://github.com/crealytics/spark-excel/issues/550

### DIFF
--- a/src/main/scala/com/crealytics/spark/v2/excel/ExcelGenerator.scala
+++ b/src/main/scala/com/crealytics/spark/v2/excel/ExcelGenerator.scala
@@ -114,7 +114,7 @@ class ExcelGenerator(val path: String, val dataSchema: StructType, val conf: Con
 
     case TimestampType =>
       (row: InternalRow, ordinal: Int, cell: Cell) => {
-        cell.setCellValue(new java.util.Date(row.getLong(ordinal).toLong))
+        cell.setCellValue(DateTimeUtils.toJavaTimestamp(row.getLong(ordinal)))
         cell.setCellStyle(TimestampCellStyle)
       }
 

--- a/src/main/scala/com/crealytics/spark/v2/excel/ExcelOptions.scala
+++ b/src/main/scala/com/crealytics/spark/v2/excel/ExcelOptions.scala
@@ -16,6 +16,7 @@ import org.apache.spark.sql.catalyst.util.DateFormatter
 import org.apache.spark.sql.catalyst.util.DateTimeUtils
 import org.apache.spark.sql.catalyst.util.ParseMode
 import org.apache.spark.sql.catalyst.util.PermissiveMode
+import org.apache.spark.sql.catalyst.util.TimestampFormatter
 import org.apache.spark.sql.internal.SQLConf
 
 import java.time.ZoneId
@@ -72,8 +73,7 @@ class ExcelOptions(
 
   val dateFormat: String = parameters.getOrElse("dateFormat", DateFormatter.defaultPattern)
 
-  val timestampFormat: String = parameters
-    .getOrElse("timestampFormat", s"${DateFormatter.defaultPattern}'T'HH:mm:ss[.SSS][XXX]")
+  val timestampFormat: String = parameters.getOrElse("timestampFormat", TimestampFormatter.defaultPattern)
 
   /* Have header line when reading and writing */
   val header = getBool("header", default = true)

--- a/src/test/scala/com/crealytics/spark/v2/excel/WriteAndReadSuite.scala
+++ b/src/test/scala/com/crealytics/spark/v2/excel/WriteAndReadSuite.scala
@@ -20,6 +20,7 @@ import java.util
 import scala.collection.JavaConverters._
 import java.nio.file.Files
 import java.sql.{Date, Timestamp}
+import java.time.{Instant, LocalDate}
 
 import com.holdenkarau.spark.testing.DataFrameSuiteBase
 
@@ -80,12 +81,20 @@ object WriteAndReadSuite {
     )
   )
 
-  val expectedData_03: util.List[Row] = List(
+  val expectedData_03_sql: util.List[Row] = List(
     Row(1, Date.valueOf("2021-10-01"), Timestamp.valueOf("2021-10-01 01:23:45")),
     Row(2, Date.valueOf("2021-11-01"), Timestamp.valueOf("2021-11-01 11:23:45")),
     Row(3, Date.valueOf("2021-10-11"), Timestamp.valueOf("2021-10-11 01:23:45")),
     Row(4, Date.valueOf("2021-11-11"), Timestamp.valueOf("2021-11-11 01:23:05")),
     Row(5, Date.valueOf("2022-10-01"), Timestamp.valueOf("2022-10-01 16:23:45"))
+  ).asJava
+
+  val expectedData_03_time: util.List[Row] = List(
+    Row(1, LocalDate.parse("2021-10-01"), Instant.parse("2021-10-01T01:23:45Z")),
+    Row(2, LocalDate.parse("2021-11-01"), Instant.parse("2021-11-01T11:23:45Z")),
+    Row(3, LocalDate.parse("2021-10-11"), Instant.parse("2021-10-11T01:23:45Z")),
+    Row(4, LocalDate.parse("2021-11-11"), Instant.parse("2021-11-11T01:23:05Z")),
+    Row(5, LocalDate.parse("2022-10-01"), Instant.parse("2022-10-01T16:23:45Z"))
   ).asJava
 }
 
@@ -149,7 +158,7 @@ class WriteAndReadSuite extends AnyFunSuite with DataFrameSuiteBase with ExcelTe
   test("write then read java.sql.date and java.sql.timestamp") {
     val path = Files.createTempDirectory("spark_excel_wr_03_").toString()
     spark.conf.set(DATETIME_JAVA8API_ENABLED, false)
-    val df_source = spark.createDataFrame(expectedData_03, userDefinedSchema_03).sort("Id")
+    val df_source = spark.createDataFrame(expectedData_03_sql, userDefinedSchema_03).sort("Id")
     df_source.write.format("excel").mode(SaveMode.Append).save(path)
 
     val df_read = spark.read
@@ -168,7 +177,7 @@ class WriteAndReadSuite extends AnyFunSuite with DataFrameSuiteBase with ExcelTe
   test("write then read java.time.Instant and java.time.LocalDate") {
     val path = Files.createTempDirectory("spark_excel_wr_03_").toString()
     spark.conf.set(DATETIME_JAVA8API_ENABLED, true)
-    val df_source = spark.createDataFrame(expectedData_03, userDefinedSchema_03).sort("Id")
+    val df_source = spark.createDataFrame(expectedData_03_time, userDefinedSchema_03).sort("Id")
     df_source.write.format("excel").mode(SaveMode.Append).save(path)
 
     val df_read = spark.read

--- a/src/test/scala/com/crealytics/spark/v2/excel/WriteAndReadSuite.scala
+++ b/src/test/scala/com/crealytics/spark/v2/excel/WriteAndReadSuite.scala
@@ -22,10 +22,11 @@ import java.nio.file.Files
 import java.sql.{Date, Timestamp}
 
 import com.holdenkarau.spark.testing.DataFrameSuiteBase
-import org.apache.spark.sql.internal.SQLConf
 
 /** Writing and reading back */
 object WriteAndReadSuite {
+
+  val DATETIME_JAVA8API_ENABLED = "spark.sql.datetime.java8API.enabled"
 
   val userDefinedSchema_01 = StructType(
     List(
@@ -147,7 +148,7 @@ class WriteAndReadSuite extends AnyFunSuite with DataFrameSuiteBase with ExcelTe
 
   test("write then read java.sql.date and java.sql.timestamp") {
     val path = Files.createTempDirectory("spark_excel_wr_03_").toString()
-    spark.conf.set(SQLConf.DATETIME_JAVA8API_ENABLED.key, false)
+    spark.conf.set(DATETIME_JAVA8API_ENABLED, false)
     val df_source = spark.createDataFrame(expectedData_03, userDefinedSchema_03).sort("Id")
     df_source.write.format("excel").mode(SaveMode.Append).save(path)
 
@@ -160,13 +161,13 @@ class WriteAndReadSuite extends AnyFunSuite with DataFrameSuiteBase with ExcelTe
     assertDataFrameEquals(df_source, df_read)
 
     /* Cleanup, should after the checking */
-    spark.conf.unset(SQLConf.DATETIME_JAVA8API_ENABLED.key)
+    spark.conf.unset(DATETIME_JAVA8API_ENABLED)
     deleteDirectory(path)
   }
 
   test("write then read java.time.Instant and java.time.LocalDate") {
     val path = Files.createTempDirectory("spark_excel_wr_03_").toString()
-    spark.conf.set(SQLConf.DATETIME_JAVA8API_ENABLED.key, true)
+    spark.conf.set(DATETIME_JAVA8API_ENABLED, true)
     val df_source = spark.createDataFrame(expectedData_03, userDefinedSchema_03).sort("Id")
     df_source.write.format("excel").mode(SaveMode.Append).save(path)
 
@@ -179,7 +180,7 @@ class WriteAndReadSuite extends AnyFunSuite with DataFrameSuiteBase with ExcelTe
     assertDataFrameEquals(df_source, df_read)
 
     /* Cleanup, should after the checking */
-    spark.conf.unset(SQLConf.DATETIME_JAVA8API_ENABLED.key)
+    spark.conf.unset(DATETIME_JAVA8API_ENABLED)
     deleteDirectory(path)
   }
 

--- a/src/test/scala/com/crealytics/spark/v2/excel/WriteAndReadSuite.scala
+++ b/src/test/scala/com/crealytics/spark/v2/excel/WriteAndReadSuite.scala
@@ -153,7 +153,7 @@ class WriteAndReadSuite extends AnyFunSuite with DataFrameSuiteBase with ExcelTe
     val path = Files.createTempDirectory("spark_excel_wr_02_").toString()
     val previousConfigValue = spark.conf.getOption(DATETIME_JAVA8API_ENABLED)
     if (previousConfigValue.isEmpty) {
-      println(DATETIME_JAVA8API_ENABLED + " didn't exist before spark 3.0. Nothing to test!")
+      print(DATETIME_JAVA8API_ENABLED + " didn't exist before spark 3.0. Nothing to test!")
       succeed
     }
     spark.conf.set(DATETIME_JAVA8API_ENABLED, true)

--- a/src/test/scala/com/crealytics/spark/v2/excel/WriteAndReadSuite.scala
+++ b/src/test/scala/com/crealytics/spark/v2/excel/WriteAndReadSuite.scala
@@ -52,7 +52,7 @@ object WriteAndReadSuite {
     Row(1, 12, "CA873", "Nguyễn Thị Teresa Teng", null, null, 1200, null, "Jesse Thomas")
   ).asJava
 
-  val userDefinedSchema_03 = StructType(
+  val userDefinedSchema_02 = StructType(
     List(
       StructField("Id", IntegerType, nullable = true),
       StructField("Date", DateType, nullable = true),
@@ -60,7 +60,7 @@ object WriteAndReadSuite {
     )
   )
 
-  val expectedData_03: List[Row] = List(
+  val expectedData_02: List[Row] = List(
     Row(1, "2021-10-01", "2021-10-01 01:23:45"),
     Row(2, "2021-11-01", "2021-11-01 11:23:45"),
     Row(3, "2021-10-11", "2021-10-11 01:23:45"),
@@ -127,13 +127,13 @@ class WriteAndReadSuite extends AnyFunSuite with DataFrameSuiteBase with ExcelTe
   }
 
   test("write then read java.sql.date and java.sql.timestamp") {
-    val path = Files.createTempDirectory("spark_excel_wr_03_").toString()
-    val previousConfigValue = spark.conf.get(DATETIME_JAVA8API_ENABLED)
+    val path = Files.createTempDirectory("spark_excel_wr_02_").toString()
+    val previousConfigValue = spark.conf.get(DATETIME_JAVA8API_ENABLED, "false")
     spark.conf.set(DATETIME_JAVA8API_ENABLED, false)
-    val expectedData_03_sql = expectedData_03
+    val expectedData_02_sql = expectedData_02
       .map(r => Row.fromTuple(r.getInt(0), Date.valueOf(r.getString(1)), Timestamp.valueOf(r.getString(2))))
       .asJava
-    val df_source = spark.createDataFrame(expectedData_03_sql, userDefinedSchema_03).sort("Id")
+    val df_source = spark.createDataFrame(expectedData_02_sql, userDefinedSchema_02).sort("Id")
     df_source.write.format("excel").mode(SaveMode.Append).save(path)
 
     val df_read = spark.read
@@ -150,17 +150,17 @@ class WriteAndReadSuite extends AnyFunSuite with DataFrameSuiteBase with ExcelTe
   }
 
   test("write then read java.time.Instant and java.time.LocalDate") {
-    val path = Files.createTempDirectory("spark_excel_wr_03_").toString()
-    val previousConfigValue = spark.conf.get(DATETIME_JAVA8API_ENABLED)
+    val path = Files.createTempDirectory("spark_excel_wr_02_").toString()
+    val previousConfigValue = spark.conf.get(DATETIME_JAVA8API_ENABLED, "false")
     spark.conf.set(DATETIME_JAVA8API_ENABLED, true)
     val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss").withZone(ZoneId.systemDefault)
-    val expectedData_03_time = expectedData_03
+    val expectedData_02_time = expectedData_02
       .map(r => Row.fromTuple(
         r.getInt(0),
         LocalDate.parse(r.getString(1)),
         Instant.from(formatter.parse(r.getString(2)))))
       .asJava
-    val df_source = spark.createDataFrame(expectedData_03_time, userDefinedSchema_03).sort("Id")
+    val df_source = spark.createDataFrame(expectedData_02_time, userDefinedSchema_02).sort("Id")
     df_source.write.format("excel").mode(SaveMode.Append).save(path)
 
     val df_read = spark.read


### PR DESCRIPTION
Hey @nightscape, @quanghgx!
I tried a fix for 550 but I can't seem to get it working for timestamps. The current code doesn't seem to generate a valid timestamp when writing excel files for v2 (as you can see from the test). I also tried `DateTimeUtils.toJavaTimestamp(row.getLong(ordinal))` which seems like it should be the clean solution and a bunch of variations on it but without success. Do you guys have any idea how I could get this working?

Thanks!