### PR TITLE
Build with version spark version : 3.1.3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ val scala213 = "2.13.8"
 val scala212 = "2.12.15"
 val spark24 = List("2.4.1", "2.4.7", "2.4.8")
 val spark30 = List("3.0.1", "3.0.3")
-val spark31 = List("3.1.1", "3.1.2")
+val spark31 = List("3.1.1", "3.1.2", "3.1.3")
 val spark32 = List("3.2.1")
 inThisBuild(
   List(


### PR DESCRIPTION
Please, Can you support version 3.1.3. 
We use your project with GCP dataproc 2.x. Dataproc use spark 3.1.3. 
https://cloud.google.com/dataproc/docs/concepts/versioning/dataproc-release-2.0

Thank you.