### PR TITLE
support tempFileThreshold param

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ val df = spark.read
     .option("timestampFormat", "MM-dd-yyyy HH:mm:ss") // Optional, default: yyyy-mm-dd hh:mm:ss[.fffffffff]
     .option("maxRowsInMemory", 20) // Optional, default None. If set, uses a streaming reader which can help with big files (will fail if used with xls format files)
     .option("maxByteArraySize", 2147483647) // Optional, default None. See https://poi.apache.org/apidocs/5.0/org/apache/poi/util/IOUtils.html#setByteArrayMaxOverride-int-
+    .option("tempFileThreshold", 10000000) // Optional, default None. Number of bytes at which a zip entry is regarded as too large for holding in memory and the data is put in a temp file instead
     .option("excerptSize", 10) // Optional, default: 10. If set and if schema inferred, number of rows to infer schema from
     .option("workbookPassword", "pass") // Optional, default None. Requires unlimited strength JCE for older JVMs
     .schema(myCustomSchema) // Optional, default: Either inferred schema, or all columns are Strings
@@ -117,6 +118,7 @@ val df = spark.read.excel(
     timestampFormat = "MM-dd-yyyy HH:mm:ss",  // Optional, default: yyyy-mm-dd hh:mm:ss[.fffffffff]
     maxRowsInMemory = 20,  // Optional, default None. If set, uses a streaming reader which can help with big files (will fail if used with xls format files)
     maxByteArraySize = 2147483647,  // Optional, default None. See https://poi.apache.org/apidocs/5.0/org/apache/poi/util/IOUtils.html#setByteArrayMaxOverride-int-
+    tempFileThreshold = 10000000, // Optional, default None. Number of bytes at which a zip entry is regarded as too large for holding in memory and the data is put in a temp file instead
     excerptSize = 10,  // Optional, default: 10. If set and if schema inferred, number of rows to infer schema from
     workbookPassword = "pass"  // Optional, default None. Requires unlimited strength JCE for older JVMs
 ).schema(myCustomSchema) // Optional, default: Either inferred schema, or all columns are Strings

--- a/src/main/scala/com/crealytics/spark/excel/package.scala
+++ b/src/main/scala/com/crealytics/spark/excel/package.scala
@@ -83,6 +83,7 @@ package object excel {
       timestampFormat: String = null,
       maxRowsInMemory: java.lang.Integer = null,
       maxByteArraySize: java.lang.Integer = null,
+      tempFileThreshold: java.lang.Integer = null,
       excerptSize: Int = 10,
       workbookPassword: String = null
     ): DataFrameReader = {
@@ -97,6 +98,7 @@ package object excel {
         "timestampFormat" -> timestampFormat,
         "maxRowsInMemory" -> maxRowsInMemory,
         "maxByteArraySize" -> maxByteArraySize,
+        "tempFileThreshold" -> tempFileThreshold,
         "excerptSize" -> excerptSize,
         "workbookPassword" -> workbookPassword
       ).foldLeft(dataFrameReader.format("com.crealytics.spark.excel")) { case (dfReader, (key, value)) =>

--- a/src/main/scala/com/crealytics/spark/v2/excel/ExcelHelper.scala
+++ b/src/main/scala/com/crealytics/spark/v2/excel/ExcelHelper.scala
@@ -19,6 +19,7 @@ package com.crealytics.spark.v2.excel
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileSystem, Path}
 import org.apache.poi.hssf.usermodel.HSSFWorkbookFactory
+import org.apache.poi.openxml4j.util.ZipInputStreamZipEntrySource
 import org.apache.poi.ss.SpreadsheetVersion
 import org.apache.poi.ss.usermodel.{Cell, CellType, DataFormatter, FormulaError, Workbook, WorkbookFactory}
 import org.apache.poi.ss.util.{AreaReference, CellReference}
@@ -202,6 +203,9 @@ object ExcelHelper {
     configureProvidersOnce() // ExcelHelper ctor is private, so we guarantee that this is called!
     options.maxByteArraySize.foreach { maxSize =>
       IOUtils.setByteArrayMaxOverride(maxSize)
+    }
+    options.tempFileThreshold.foreach { threshold =>
+      ZipInputStreamZipEntrySource.setThresholdBytesForTempFiles(threshold)
     }
     new ExcelHelper(options)
   }

--- a/src/main/scala/com/crealytics/spark/v2/excel/ExcelOptions.scala
+++ b/src/main/scala/com/crealytics/spark/v2/excel/ExcelOptions.scala
@@ -146,4 +146,10 @@ class ExcelOptions(
     * href="https://poi.apache.org/apidocs/5.0/org/apache/poi/util/IOUtils.html#setByteArrayMaxOverride-int-">maxByteArraySize</a>
     */
   val maxByteArraySize = getInt("maxByteArraySize")
+
+  // scalastyle:on
+  /** Optional parameter for specifying the number of bytes at which a zip entry is regarded as too large for holding in
+    * memory and the data is put in a temp file instead - useful for sheets with a lot of data
+    */
+  val tempFileThreshold = getInt("tempFileThreshold")
 }


### PR DESCRIPTION
Another param to help with processing large xlsx files.

Similar to https://github.com/crealytics/spark-excel/pull/613/files

See https://poi.apache.org/components/configuration.html

And https://github.com/crealytics/spark-excel/issues/590#issuecomment-1190046525