### PR TITLE
ExcelGenerator should support boolean type

### DIFF
--- a/src/main/scala/com/crealytics/spark/v2/excel/ExcelGenerator.scala
+++ b/src/main/scala/com/crealytics/spark/v2/excel/ExcelGenerator.scala
@@ -129,6 +129,12 @@ class ExcelGenerator(val path: String, val dataSchema: StructType, val conf: Con
         cell.setCellStyle(StringCellStyle)
       }
 
+    case BooleanType =>
+      (row: InternalRow, ordinal: Int, cell: Cell) => {
+        cell.setCellValue(row.getBoolean(ordinal))
+        cell.setCellStyle(WholeNumberCellStyle)
+      }
+
     case _ => throw new RuntimeException(s"Unsupported type: ${dataType.typeName}")
   }
 

--- a/src/test/scala/com/crealytics/spark/v2/excel/WriteAndReadSuite.scala
+++ b/src/test/scala/com/crealytics/spark/v2/excel/WriteAndReadSuite.scala
@@ -45,16 +45,17 @@ object WriteAndReadSuite {
       StructField("Extra Option 1", IntegerType, true),
       StructField("Extra Option 2", IntegerType, true),
       StructField("Extra Option 3", IntegerType, true),
+      StructField("Rewards Customer", BooleanType, true),
       StructField("Staff", StringType, true)
     )
   )
 
   val expectedData_01: util.List[Row] = List(
-    Row(1, 12, "CA869", "Phạm Uyển Trinh", null, null, 2200, null, "Ella Fitzgerald"),
-    Row(1, 12, "CA870", "Nguyễn Liên Thảo", null, null, 2000, 1350, "Ella Fitzgerald"),
-    Row(1, 12, "CA871", "Lê Thị Nga", 17000, null, null, null, "Ella Fitzgerald"),
-    Row(1, 12, "CA872", "Phan Tố Nga", null, null, 2000, null, "Teresa Teng"),
-    Row(1, 12, "CA873", "Nguyễn Thị Teresa Teng", null, null, 1200, null, "Jesse Thomas")
+    Row(1, 12, "CA869", "Phạm Uyển Trinh", null, null, 2200, null, true, "Ella Fitzgerald"),
+    Row(1, 12, "CA870", "Nguyễn Liên Thảo", null, null, 2000, 1350, false, "Ella Fitzgerald"),
+    Row(1, 12, "CA871", "Lê Thị Nga", 17000, null, null, null, false, "Ella Fitzgerald"),
+    Row(1, 12, "CA872", "Phan Tố Nga", null, null, 2000, null, true, "Teresa Teng"),
+    Row(1, 12, "CA873", "Nguyễn Thị Teresa Teng", null, null, 1200, null, null, "Jesse Thomas")
   ).asJava
 
   val userDefinedSchema_02 = StructType(
@@ -71,12 +72,6 @@ object WriteAndReadSuite {
     Row(3, "2021-10-11", "2021-10-11 01:23:45"),
     Row(4, "2021-11-11", "2021-11-11 01:23:05"),
     Row(5, "2022-10-01", "2022-10-01 16:23:45")
-  )
-
-  val expectedData_bool: List[Row] = List(Row(1, true), Row(2, false))
-
-  val userDefinedSchema_bool = StructType(
-    List(StructField("Id", IntegerType, nullable = true), StructField("Bool", BooleanType, nullable = true))
   )
 }
 
@@ -190,31 +185,6 @@ class WriteAndReadSuite extends AnyFunSuite with DataFrameSuiteBase with ExcelTe
 
     /* Cleanup, should after the checking */
     spark.conf.set(DATETIME_JAVA8API_ENABLED, previousConfigValue)
-    deleteDirectory(path)
-  }
-
-  test("write then read boolean") {
-    val path = Files.createTempDirectory("spark_excel_wr_bool_").toString()
-    val previousConfigValue = spark.conf.getOption(DATETIME_JAVA8API_ENABLED)
-    spark.conf.set(DATETIME_JAVA8API_ENABLED, false)
-    val expectedData_bool_sql = expectedData_bool.asJava
-    val df_source = spark.createDataFrame(expectedData_bool_sql, userDefinedSchema_bool).sort("Id")
-    df_source.write.format("excel").mode(SaveMode.Append).save(path)
-
-    val df_read = spark.read
-      .format("excel")
-      .schema(userDefinedSchema_bool)
-      .load(path)
-      .sort("Id")
-
-    assertDataFrameEquals(df_source, df_read)
-
-    /* Cleanup, should after the checking */
-    if (previousConfigValue.isEmpty) {
-      spark.conf.unset(DATETIME_JAVA8API_ENABLED)
-    } else {
-      spark.conf.set(DATETIME_JAVA8API_ENABLED, previousConfigValue.get)
-    }
     deleteDirectory(path)
   }
 

--- a/src/test/scala/com/crealytics/spark/v2/excel/WriteAndReadSuite.scala
+++ b/src/test/scala/com/crealytics/spark/v2/excel/WriteAndReadSuite.scala
@@ -72,6 +72,12 @@ object WriteAndReadSuite {
     Row(4, "2021-11-11", "2021-11-11 01:23:05"),
     Row(5, "2022-10-01", "2022-10-01 16:23:45")
   )
+
+  val expectedData_bool: List[Row] = List(Row(1, true), Row(2, false))
+
+  val userDefinedSchema_bool = StructType(
+    List(StructField("Id", IntegerType, nullable = true), StructField("Bool", BooleanType, nullable = true))
+  )
 }
 
 /** Write then read excel file, with both XLSX and XLS formats. There are two open questions:
@@ -184,6 +190,31 @@ class WriteAndReadSuite extends AnyFunSuite with DataFrameSuiteBase with ExcelTe
 
     /* Cleanup, should after the checking */
     spark.conf.set(DATETIME_JAVA8API_ENABLED, previousConfigValue)
+    deleteDirectory(path)
+  }
+
+  test("write then read boolean") {
+    val path = Files.createTempDirectory("spark_excel_wr_bool_").toString()
+    val previousConfigValue = spark.conf.getOption(DATETIME_JAVA8API_ENABLED)
+    spark.conf.set(DATETIME_JAVA8API_ENABLED, false)
+    val expectedData_bool_sql = expectedData_bool.asJava
+    val df_source = spark.createDataFrame(expectedData_bool_sql, userDefinedSchema_bool).sort("Id")
+    df_source.write.format("excel").mode(SaveMode.Append).save(path)
+
+    val df_read = spark.read
+      .format("excel")
+      .schema(userDefinedSchema_bool)
+      .load(path)
+      .sort("Id")
+
+    assertDataFrameEquals(df_source, df_read)
+
+    /* Cleanup, should after the checking */
+    if (previousConfigValue.isEmpty) {
+      spark.conf.unset(DATETIME_JAVA8API_ENABLED)
+    } else {
+      spark.conf.set(DATETIME_JAVA8API_ENABLED, previousConfigValue.get)
+    }
     deleteDirectory(path)
   }
 


### PR DESCRIPTION
Relates to https://github.com/crealytics/spark-excel/issues/623

ExcelGenerator is missing cases for a large number of other data types.
