### PR TITLE
closed stream issue (issue #650)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -80,7 +80,10 @@ libraryDependencies ++= Seq(
   "org.apache.spark" %% "spark-core" % testSparkVersion.value % "provided",
   "org.apache.spark" %% "spark-sql" % testSparkVersion.value % "provided",
   "org.apache.spark" %% "spark-hive" % testSparkVersion.value % "provided",
+  "org.apache.hadoop" % "hadoop-common" % "3.3.1" % Test,
+  "org.apache.hadoop" % "hadoop-auth" % "3.3.1" % Test,
   "org.scala-lang.modules" %% "scala-collection-compat" % "2.8.1",
+  "com.github.bigwheel" %% "util-backports" % "2.1",
   "org.typelevel" %% "cats-core" % "2.8.0" % Test,
   "org.scalatest" %% "scalatest" % "3.2.13" % Test,
   "org.scalatestplus" %% "scalacheck-1-15" % "3.2.11.0" % Test,
@@ -93,7 +96,7 @@ libraryDependencies ++= Seq(
 
 // Custom source layout for Spark Data Source API 2
 Compile / unmanagedSourceDirectories := {
-  if (testSparkVersion.value >= "3.2.2") {
+  if (testSparkVersion.value >= "3.2.0") {
     Seq(
       (Compile / sourceDirectory)(_ / "scala"),
       (Compile / sourceDirectory)(_ / "3.x/scala"),

--- a/build.sbt
+++ b/build.sbt
@@ -80,10 +80,10 @@ libraryDependencies ++= Seq(
   "org.apache.spark" %% "spark-core" % testSparkVersion.value % "provided",
   "org.apache.spark" %% "spark-sql" % testSparkVersion.value % "provided",
   "org.apache.spark" %% "spark-hive" % testSparkVersion.value % "provided",
+  // added hadoop libs to test allowing to execute the tests locally (from within intellij)
   "org.apache.hadoop" % "hadoop-common" % "3.3.1" % Test,
   "org.apache.hadoop" % "hadoop-auth" % "3.3.1" % Test,
   "org.scala-lang.modules" %% "scala-collection-compat" % "2.8.1",
-  "com.github.bigwheel" %% "util-backports" % "2.1",
   "org.typelevel" %% "cats-core" % "2.8.0" % Test,
   "org.scalatest" %% "scalatest" % "3.2.13" % Test,
   "org.scalatestplus" %% "scalacheck-1-15" % "3.2.11.0" % Test,

--- a/build.sbt
+++ b/build.sbt
@@ -80,10 +80,6 @@ libraryDependencies ++= Seq(
   "org.apache.spark" %% "spark-core" % testSparkVersion.value % "provided",
   "org.apache.spark" %% "spark-sql" % testSparkVersion.value % "provided",
   "org.apache.spark" %% "spark-hive" % testSparkVersion.value % "provided",
-  // added hadoop libs to test allowing to execute the tests locally (from within intellij)
-  // TODO removed to make unit tests work on CI?
-  // "org.apache.hadoop" % "hadoop-common" % "3.3.1" % Test,
-  // "org.apache.hadoop" % "hadoop-auth" % "3.3.1" % Test,
   "org.scala-lang.modules" %% "scala-collection-compat" % "2.8.1",
   "org.typelevel" %% "cats-core" % "2.8.0" % Test,
   "org.scalatest" %% "scalatest" % "3.2.13" % Test,
@@ -93,7 +89,11 @@ libraryDependencies ++= Seq(
   //  "com.holdenkarau" %% "spark-testing-base" % s"${testSparkVersion.value}_0.7.4" % Test,
   "org.scalamock" %% "scalamock" % "5.2.0" % Test
 ) ++ (if (scalaVersion.value.startsWith("2.12")) Seq("com.github.nightscape" %% "spark-testing-base" % "9496d55" % Test)
-      else Seq())
+      else Seq()) ++ (
+  if (!sys.env.contains("CI"))
+    Seq("org.apache.hadoop" % "hadoop-common" % "3.3.1" % Test, "org.apache.hadoop" % "hadoop-auth" % "3.3.1" % Test)
+  else Seq()
+)
 
 // Custom source layout for Spark Data Source API 2
 Compile / unmanagedSourceDirectories := {

--- a/build.sbt
+++ b/build.sbt
@@ -81,8 +81,9 @@ libraryDependencies ++= Seq(
   "org.apache.spark" %% "spark-sql" % testSparkVersion.value % "provided",
   "org.apache.spark" %% "spark-hive" % testSparkVersion.value % "provided",
   // added hadoop libs to test allowing to execute the tests locally (from within intellij)
-  "org.apache.hadoop" % "hadoop-common" % "3.3.1" % Test,
-  "org.apache.hadoop" % "hadoop-auth" % "3.3.1" % Test,
+  // TODO removed to make unit tests work on CI?
+  // "org.apache.hadoop" % "hadoop-common" % "3.3.1" % Test,
+  // "org.apache.hadoop" % "hadoop-auth" % "3.3.1" % Test,
   "org.scala-lang.modules" %% "scala-collection-compat" % "2.8.1",
   "org.typelevel" %% "cats-core" % "2.8.0" % Test,
   "org.scalatest" %% "scalatest" % "3.2.13" % Test,

--- a/src/main/3.x/scala/com/crealytics/spark/v2/excel/ExcelPartitionReaderFactory.scala
+++ b/src/main/3.x/scala/com/crealytics/spark/v2/excel/ExcelPartitionReaderFactory.scala
@@ -17,6 +17,7 @@
 package com.crealytics.spark.v2.excel
 
 import org.apache.hadoop.conf.Configuration
+import org.apache.poi.ss.usermodel.Cell
 import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.connector.read.PartitionReader
@@ -76,8 +77,13 @@ case class ExcelPartitionReaderFactory(
     requiredSchema: StructType
   ): Iterator[InternalRow] = {
     val excelHelper = ExcelHelper(parsedOptions)
-    val rows = excelHelper.getRows(conf, URI.create(file.filePath))
+
+    val workbook = excelHelper.getWorkbook(conf, URI.create(file.filePath))
+    val excelReader = DataLocator(parsedOptions)
+    val rows = excelReader.readFrom(workbook)
+
     ExcelParser.parseIterator(rows, parser, headerChecker, requiredSchema)
+
   }
 
 }

--- a/src/main/3.x/scala/com/crealytics/spark/v2/excel/ExcelPartitionReaderFromIterator.scala
+++ b/src/main/3.x/scala/com/crealytics/spark/v2/excel/ExcelPartitionReaderFromIterator.scala
@@ -2,6 +2,7 @@ package com.crealytics.spark.v2.excel
 
 import org.apache.hadoop.conf.Configuration
 import org.apache.poi.ss.usermodel.Workbook
+import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.execution.datasources.PartitionedFile
 import org.apache.spark.sql.execution.datasources.v2._
@@ -14,12 +15,14 @@ import java.net.URI
   *
   * Need to be instantiated via apply() method
   */
-private[excel] class ExcelPartitionReaderFromIterator[InternalRow] private (
-  workbook: Workbook,
-  iter: Iterator[InternalRow]
-) extends PartitionReaderFromIterator[InternalRow](iter) {
+private[excel] class ExcelPartitionReaderFromIterator[T] private (workbook: Workbook, iter: Iterator[T])
+    extends PartitionReaderFromIterator[T](iter)
+    with Logging {
 
-  override def close(): Unit = workbook.close()
+  override def close(): Unit = {
+    log.error("Close workbook")
+    workbook.close()
+  }
 
 }
 

--- a/src/main/3.x/scala/com/crealytics/spark/v2/excel/ExcelPartitionReaderFromIterator.scala
+++ b/src/main/3.x/scala/com/crealytics/spark/v2/excel/ExcelPartitionReaderFromIterator.scala
@@ -20,7 +20,7 @@ private[excel] class ExcelPartitionReaderFromIterator[T] private (workbook: Work
     with Logging {
 
   override def close(): Unit = {
-    log.error("Close workbook")
+    // log.error("Close workbook partition reader")
     workbook.close()
   }
 

--- a/src/main/3.x/scala/com/crealytics/spark/v2/excel/ExcelPartitionReaderFromIterator.scala
+++ b/src/main/3.x/scala/com/crealytics/spark/v2/excel/ExcelPartitionReaderFromIterator.scala
@@ -1,0 +1,44 @@
+package com.crealytics.spark.v2.excel
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.poi.ss.usermodel.Workbook
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.execution.datasources.PartitionedFile
+import org.apache.spark.sql.execution.datasources.v2._
+import org.apache.spark.sql.types.StructType
+
+import java.net.URI
+
+/** ExcelPartitionReaderFromIterator is a lightweight wrapper around spark PartitionReaderFromIterator that implements
+  * the close() method, which closes the provided Excel Workbook after the read is done
+  *
+  * Need to be instantiated via apply() method
+  */
+private[excel] class ExcelPartitionReaderFromIterator[InternalRow] private (
+  workbook: Workbook,
+  iter: Iterator[InternalRow]
+) extends PartitionReaderFromIterator[InternalRow](iter) {
+
+  override def close(): Unit = workbook.close()
+
+}
+
+private[excel] object ExcelPartitionReaderFromIterator {
+  def apply(
+    conf: Configuration,
+    parsedOptions: ExcelOptions,
+    file: PartitionedFile,
+    parser: ExcelParser,
+    headerChecker: ExcelHeaderChecker,
+    requiredSchema: StructType
+  ): ExcelPartitionReaderFromIterator[InternalRow] = {
+    val excelHelper = ExcelHelper(parsedOptions)
+
+    val workbook = excelHelper.getWorkbook(conf, URI.create(file.filePath))
+    val excelReader = DataLocator(parsedOptions)
+    val rows = excelReader.readFrom(workbook)
+
+    val iter = ExcelParser.parseIterator(rows, parser, headerChecker, requiredSchema)
+    new ExcelPartitionReaderFromIterator[InternalRow](workbook, iter)
+  }
+}

--- a/src/main/scala/com/crealytics/spark/v2/excel/ExcelHelper.scala
+++ b/src/main/scala/com/crealytics/spark/v2/excel/ExcelHelper.scala
@@ -135,7 +135,6 @@ class ExcelHelper private (options: ExcelOptions) {
   def getRows(conf: Configuration, uri: URI): Iterator[Vector[Cell]] = {
     val workbook = getWorkbook(conf, uri)
     val excelReader = DataLocator(options)
-    // todo this does not work with streaming reader
     try { excelReader.readFrom(workbook) }
     finally workbook.close()
   }

--- a/src/main/scala/com/crealytics/spark/v2/excel/ExcelHelper.scala
+++ b/src/main/scala/com/crealytics/spark/v2/excel/ExcelHelper.scala
@@ -135,6 +135,7 @@ class ExcelHelper private (options: ExcelOptions) {
   def getRows(conf: Configuration, uri: URI): Iterator[Vector[Cell]] = {
     val workbook = getWorkbook(conf, uri)
     val excelReader = DataLocator(options)
+    // todo this does not work with streaming reader
     try { excelReader.readFrom(workbook) }
     finally workbook.close()
   }

--- a/src/main/scala/com/crealytics/spark/v2/excel/ExcelHelper.scala
+++ b/src/main/scala/com/crealytics/spark/v2/excel/ExcelHelper.scala
@@ -139,10 +139,11 @@ class ExcelHelper private (options: ExcelOptions) extends Logging {
     val excelReader = DataLocator(options)
     try { excelReader.readFrom(workbook) }
     finally {
-      if (workbook.isInstanceOf[StreamingWorkbook])
-        log.error("getrows close workbook not done for streaming workbook")
-      else
+      if (workbook.isInstanceOf[StreamingWorkbook]) {
+        log.error("getrows close workbook not done for streaming workbook ")
+      } else {
         workbook.close()
+      }
     }
   }
 

--- a/src/test/scala/com/crealytics/spark/v2/excel/MaxNumRowsSuite.scala
+++ b/src/test/scala/com/crealytics/spark/v2/excel/MaxNumRowsSuite.scala
@@ -23,24 +23,29 @@ class MaxNumRowsSuite extends AnyWordSpec with DataFrameSuiteBase with LocalFile
 
   "excel v2 and maxNumRows" can {
 
-    "read with maxNumRows=200" in {
+    case class Testcase(hasHeader: Boolean, doInferSchema: Boolean, numRows: Int, maxRowsInMemory: Int)
 
-      val dfExcel = spark.read
-        .format("excel")
-        // .format("com.crealytics.spark.excel")
-        .option("path", "src/test/resources/v2readwritetest/large_excel/largefile-wide-single-sheet.xlsx")
-        .option("header", value = false)
-        // .option("dataAddress", "'Sheet1'!B7:M16")
-        .option("maxRowsInMemory", "200")
-        .option("inferSchema", false)
-        .load()
+    val allTestcases = Seq(
+      Testcase(hasHeader = false, doInferSchema = false, numRows = 2242, maxRowsInMemory = 200),
+      Testcase(hasHeader = true, doInferSchema = false, numRows = 2241, maxRowsInMemory = 200),
+      Testcase(hasHeader = true, doInferSchema = true, numRows = 2241, maxRowsInMemory = 200)
+    )
 
-      assert(dfExcel.count() == 2241)
+    for (testcase <- allTestcases) {
+      s"v2 streaming read (header = ${testcase.hasHeader}, inferSchema = ${testcase.doInferSchema}, " +
+        s"maxRowsInMemory = ${testcase.maxRowsInMemory})" in {
 
-      // val maxId = dfExcel.select(max("seq")).first().getInt(0)
-      // assert(maxId == 60000)
+          val dfExcel = spark.read
+            .format("excel")
+            .option("path", "src/test/resources/v2readwritetest/large_excel/largefile-wide-single-sheet.xlsx")
+            .option("header", value = testcase.hasHeader)
+            .option("maxRowsInMemory", testcase.maxRowsInMemory)
+            .option("inferSchema", testcase.doInferSchema)
+            .load()
 
+          assert(dfExcel.count() == testcase.numRows)
+
+        }
     }
-
   }
 }

--- a/src/test/scala/com/crealytics/spark/v2/excel/MaxNumRowsSuite.scala
+++ b/src/test/scala/com/crealytics/spark/v2/excel/MaxNumRowsSuite.scala
@@ -39,7 +39,7 @@ class MaxNumRowsSuite extends AnyWordSpec with DataFrameSuiteBase with LocalFile
             .format("excel")
             .option("path", "src/test/resources/v2readwritetest/large_excel/largefile-wide-single-sheet.xlsx")
             .option("header", value = testcase.hasHeader)
-            .option("maxRowsInMemory", testcase.maxRowsInMemory)
+            .option("maxRowsInMemory", testcase.maxRowsInMemory.toString)
             .option("inferSchema", testcase.doInferSchema)
             .load()
 

--- a/src/test/scala/com/crealytics/spark/v2/excel/MaxNumRowsSuite.scala
+++ b/src/test/scala/com/crealytics/spark/v2/excel/MaxNumRowsSuite.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2022 Martin Mauch (@nightscape)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.crealytics.spark.v2.excel
+
+import com.holdenkarau.spark.testing.DataFrameSuiteBase
+import org.apache.spark.sql._
+import org.apache.spark.sql.functions.{col, max}
+import org.scalatest.wordspec.AnyWordSpec
+
+class MaxNumRowsSuite extends AnyWordSpec with DataFrameSuiteBase with LocalFileTestingUtilities {
+
+  "excel v2 and maxNumRows" can {
+
+    s"read with maxNumRows=200" in {
+
+      val dfExcel = spark.read
+        .format("excel")
+        // .format("com.crealytics.spark.excel")
+        .option("path", "src/test/resources/v2readwritetest/large_excel/largefile-wide-single-sheet.xlsx")
+        .option("header", value = false)
+        // .option("dataAddress", "'Sheet1'!B7:M16")
+        .option("maxRowsInMemory", "200")
+        .option("inferSchema", false)
+        .load()
+
+      assert(dfExcel.count() == 2241)
+
+      // val maxId = dfExcel.select(max("seq")).first().getInt(0)
+      // assert(maxId == 60000)
+
+    }
+
+  }
+}

--- a/src/test/scala/com/crealytics/spark/v2/excel/MaxNumRowsSuite.scala
+++ b/src/test/scala/com/crealytics/spark/v2/excel/MaxNumRowsSuite.scala
@@ -23,7 +23,7 @@ class MaxNumRowsSuite extends AnyWordSpec with DataFrameSuiteBase with LocalFile
 
   "excel v2 and maxNumRows" can {
 
-    s"read with maxNumRows=200" in {
+    "read with maxNumRows=200" in {
 
       val dfExcel = spark.read
         .format("excel")

--- a/src/test/scala/com/crealytics/spark/v2/excel/MaxNumRowsSuite.scala
+++ b/src/test/scala/com/crealytics/spark/v2/excel/MaxNumRowsSuite.scala
@@ -17,8 +17,6 @@
 package com.crealytics.spark.v2.excel
 
 import com.holdenkarau.spark.testing.DataFrameSuiteBase
-import org.apache.spark.sql._
-import org.apache.spark.sql.functions.{col, max}
 import org.scalatest.wordspec.AnyWordSpec
 
 class MaxNumRowsSuite extends AnyWordSpec with DataFrameSuiteBase with LocalFileTestingUtilities {


### PR DESCRIPTION
The issue this PR tries to fix is #650 

I introduced ExcelPartitionReaderFromIterator and moved the problematic Workbook.close() to the close() method of this class. Now spark takes care of closing the file. 

The code change is pretty straightforward. Basically I moved the code from ExcelHelper.getRows and ExcelPartitionReaderFactory.readFile to the apply() of the newly introduced class. 

In the ExcelPartitionReaderFactory.buildReader() we create an instance of the new class and pass it to PartitionReaderWithPartitionValues, which is used by spark for reading the data.
`
val fileReader = ExcelPartitionReaderFromIterator(conf, parsedOptions, file, parser, headerChecker, readDataSchema)
new PartitionReaderWithPartitionValues(fileReader, readDataSchema, partitionSchema, file.partitionValues)
`
when spark finishes reading it calls close() on PartitionReaderWithPartitionValues which in turn calls close on the fileReader. There we call close on the workbook and the issue is solved.

I am not really satisifed with the method signatures, but that was the best I could come up in the given time. If someone has an idea on how to improve it pls let me know.

The PR doesn't adress ExcelHelper.getRows(). I think this function could still cause issues, because when accessing the iterator we are reading from a closed workbook.    