### PR TITLE
Bugfix Classpath problems (#696)

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -45,7 +45,7 @@ class SparkModule(_scalaVersion: String, sparkVersion: String) extends SbtModule
     Rule.Relocate("org.apache.commons.io.**", "shadeio.commons.io.@1"),
     Rule.Relocate("org.apache.commons.compress.**", "shadeio.commons.compress.@1")
   )
-  override def extraPublish = Seq(PublishInfo(assembly(), classifier = None, ivyConfig = "compile"))
+  override def extraPublish = Seq(PublishInfo(assembly(), classifier = Some("assembly"), ivyConfig = "compile"))
 
   val sparkDeps = Agg(
     ivy"org.apache.spark::spark-core:$sparkVersion",

--- a/build.sc
+++ b/build.sc
@@ -60,7 +60,7 @@ class SparkModule(_scalaVersion: String, sparkVersion: String) extends SbtModule
 
   val poiVersion = "5.2.3"
   override def ivyDeps = {
-    val base = Agg(
+    Agg(
       ivy"org.apache.poi:poi:$poiVersion",
       ivy"org.apache.poi:poi-ooxml:$poiVersion",
       ivy"org.apache.poi:poi-ooxml-lite:$poiVersion",
@@ -70,7 +70,6 @@ class SparkModule(_scalaVersion: String, sparkVersion: String) extends SbtModule
       ivy"com.github.pjfanning:poi-shared-strings:2.5.6",
       ivy"commons-io:commons-io:2.11.0",
       ivy"org.apache.commons:commons-compress:1.22",
-      ivy"org.apache.logging.log4j:log4j-api:2.19.0",
       ivy"com.zaxxer:SparseBitSet:1.2",
       ivy"org.apache.commons:commons-collections4:4.4",
       ivy"com.github.virtuald:curvesapi:1.07",
@@ -78,11 +77,6 @@ class SparkModule(_scalaVersion: String, sparkVersion: String) extends SbtModule
       ivy"org.apache.commons:commons-math3:3.6.1",
       ivy"org.scala-lang.modules::scala-collection-compat:2.9.0"
     )
-    if (sparkVersion >= "3.3.0") {
-      base ++ Agg(ivy"org.apache.logging.log4j:log4j-core:2.19.0")
-    } else {
-      base
-    }
   }
   object test extends Tests with SbtModule with TestModule.ScalaTest {
 
@@ -100,8 +94,8 @@ class SparkModule(_scalaVersion: String, sparkVersion: String) extends SbtModule
       ivy"org.scalacheck::scalacheck:1.17.0",
       ivy"com.github.alexarchambault::scalacheck-shapeless_1.15:1.3.0",
       ivy"com.github.mrpowers::spark-fast-tests:1.3.0",
-      ivy"org.scalamock::scalamock:5.2.0"
-    )
+      ivy"org.scalamock::scalamock:5.2.0",
+    ) ++ (if (sparkVersion >= "3.3.0") Agg(ivy"org.apache.logging.log4j:log4j-core:2.19.0") else Agg()) // Spark 3.3 doesnt run without a Log4j2 implementation
   }
 }
 


### PR DESCRIPTION
Publish assembly jar (fat-jar) with classifier 'assembly'. Like that the main artifact is a thin-jar, usable as maven library dependency, having it's dependencies described in the maven pom, making proper dependency resolution work again. The fat-jar can be downloaded from maven central with classifier 'assembly' in the file name.

Move log4j2 implementation needed for running spark >=3.3.0 into scope test. Remove slf4j dependency as it is not used througout the project.