### PR TITLE
Use takeWhile method from Range

### DIFF
--- a/src/main/scala/com/crealytics/spark/excel/v2/DataLocator.scala
+++ b/src/main/scala/com/crealytics/spark/excel/v2/DataLocator.scala
@@ -42,8 +42,9 @@ trait DataLocator {
         val r = sheet.getRow(rid)
         if (r == null) { Vector.empty }
         else {
+          val lastCellNum = r.getLastCellNum
           colInd
-            .filter(_ < r.getLastCellNum())
+            .takeWhile(_ < lastCellNum)
             .map(r.getCell(_, MissingCellPolicy.CREATE_NULL_AS_BLANK))
             .toVector
         }
@@ -52,12 +53,13 @@ trait DataLocator {
     } else {
       sheet.iterator.asScala
         .filter(r => rowInd.contains(r.getRowNum))
-        .map(r =>
+        .map { r =>
+          val lastCellNum = r.getLastCellNum
           colInd
-            .filter(_ < r.getLastCellNum())
+            .takeWhile(_ < lastCellNum)
             .map(r.getCell(_, MissingCellPolicy.CREATE_NULL_AS_BLANK))
             .toVector
-        )
+        }
     }
   }
 }


### PR DESCRIPTION
The symptoms:
I have a file with ~1 million rows, 125 columns. It takes ~12 seconds to count lines with spark-excel's API V1 and ~2 minutes with API V2.

The issue:
1) `Range` does not contain own optimized method `filter`, that's why it uses method from `TraversableLike` which iterates over each number in range.
2) `r.getLastCellNum` evaluated for each number in range.

Here are some rough benchmarks with another file:
filter => 50 seconds
val lastCellNum => 38 seconds
withFilter => 20 seconds
takeWhile => 12 seconds
API V1 => 12 seconds
(File taken from [here](https://data.cityofchicago.org/Public-Safety/Crimes-2018/3i3m-jwuy) and manually converted to "xlsx")

PS. API V2 seems great! :)