### PR TITLE
feat: Allow specifying date format for parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A library for querying Excel files with Apache Spark, for Spark SQL and DataFram
 
 [![Build Status](https://github.com/crealytics/spark-excel/workflows/CI/badge.svg)](https://github.com/crealytics/spark-excel/actions)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.crealytics/spark-excel_2.12/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.crealytics/spark-excel_2.12)
- 
+
 
 ## Co-maintainers wanted
 Due to personal and professional constraints, the development of this library has been rather slow.
@@ -61,7 +61,7 @@ $SPARK_HOME/bin/spark-shell --packages com.crealytics:spark-excel_2.11:<spark-ve
 * This package allows querying Excel spreadsheets as [Spark DataFrames](https://spark.apache.org/docs/latest/sql-programming-guide.html).
 * From spark-excel [0.14.0](https://github.com/crealytics/spark-excel/releases/tag/v0.14.0) (August 24, 2021), there are two implementation of spark-excel
     * Original Spark-Excel with Spark data source API 1.0
-    * Spark-Excel V2 with data source API V2.0+, which supports loading from multiple files, corrupted record handling and some improvement on handling data types. 
+    * Spark-Excel V2 with data source API V2.0+, which supports loading from multiple files, corrupted record handling and some improvement on handling data types.
       See below for further details
 
 To use V2 implementation, just change your .format from `.format("com.crealytics.spark.excel")` to `.format("excel")`.
@@ -89,6 +89,7 @@ val df = spark.read
     .option("inferSchema", "false") // Optional, default: false
     .option("addColorColumns", "true") // Optional, default: false
     .option("timestampFormat", "MM-dd-yyyy HH:mm:ss") // Optional, default: yyyy-mm-dd hh:mm:ss[.fffffffff]
+    .option("dateFormat", "yyyyMMdd") // Optional, default: yyyy-MM-dd
     .option("maxRowsInMemory", 20) // Optional, default None. If set, uses a streaming reader which can help with big files (will fail if used with xls format files)
     .option("maxByteArraySize", 2147483647) // Optional, default None. See https://poi.apache.org/apidocs/5.0/org/apache/poi/util/IOUtils.html#setByteArrayMaxOverride-int-
     .option("tempFileThreshold", 10000000) // Optional, default None. Number of bytes at which a zip entry is regarded as too large for holding in memory and the data is put in a temp file instead
@@ -224,7 +225,7 @@ spark.read
 
 
 Because folders are supported you can read/write from/to a "partitioned" folder structure, just
-the same way as csv or parquet. Note that writing partitioned structures is only 
+the same way as csv or parquet. Note that writing partitioned structures is only
 available for spark >=3.0.1
 
 ````scala

--- a/src/main/scala/com/crealytics/spark/excel/DefaultSource.scala
+++ b/src/main/scala/com/crealytics/spark/excel/DefaultSource.scala
@@ -47,6 +47,7 @@ class DefaultSource extends RelationProvider with SchemaRelationProvider with Cr
       inferSheetSchema = parameters.get("inferSchema").fold(false)(_.toBoolean),
       addColorColumns = parameters.get("addColorColumns").fold(false)(_.toBoolean),
       timestampFormat = parameters.get("timestampFormat"),
+      dateFormat = parameters.get("dateFormat"),
       excerptSize = parameters.get("excerptSize").fold(10)(_.toInt),
       dataLocator = dataLocator,
       workbookReader = wbReader


### PR DESCRIPTION
### **PR Type**
Enhancement, Documentation


___

### **Description**
- Added support for custom date parsing by introducing a `dateFormat` parameter.
- Enhanced `HeaderDataColumn` to handle date parsing using the new `parseDate` function.
- Updated `ExcelRelation` to include a `dateParser` for custom date formats.
- Documented the new `dateFormat` option in the README.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DataColumn.scala</strong><dd><code>Add support for custom date parsing in DataColumn</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/scala/com/crealytics/spark/excel/DataColumn.scala

<li>Added support for parsing date strings into <code>java.sql.Date</code>.<br> <li> Modified <code>HeaderDataColumn</code> to include <code>parseDate</code> function.<br> <li> Enhanced date extraction logic to handle different cell types.<br>


</details>


  </td>
  <td><a href="https://github.com/crealytics/spark-excel/pull/878/files#diff-8b7d2fddf33372c71cbc5d2552ccc453255f0aba87f738c6a5ae20518ae216af">+9/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>DefaultSource.scala</strong><dd><code>Introduce dateFormat parameter in DefaultSource</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/scala/com/crealytics/spark/excel/DefaultSource.scala

- Added `dateFormat` parameter to `DefaultSource`.



</details>


  </td>
  <td><a href="https://github.com/crealytics/spark-excel/pull/878/files#diff-186be9061f8ed19827a0d54bc33950bd46336c2c268f6f610754a5e8d1ce9fe4">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>ExcelRelation.scala</strong><dd><code>Support custom date parsing in ExcelRelation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/scala/com/crealytics/spark/excel/ExcelRelation.scala

<li>Added support for <code>dateFormat</code> in <code>ExcelRelation</code>.<br> <li> Implemented <code>dateParser</code> for custom date parsing.<br> <li> Updated <code>HeaderDataColumn</code> instantiation to include <code>dateParser</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/crealytics/spark-excel/pull/878/files#diff-f7648e36a17afa7b612d96420aca7447b8d0cbbc2cfcacf5e052afb75ac643fe">+12/-1</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Document dateFormat option and minor formatting fixes</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<li>Documented the new <code>dateFormat</code> option.<br> <li> Minor formatting corrections.<br>


</details>


  </td>
  <td><a href="https://github.com/crealytics/spark-excel/pull/878/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+4/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

