### PR TITLE
build: Always shade commons-compress

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -101,9 +101,25 @@ trait SparkModule extends Cross.Module2[String, String] with SbtModule with Sona
     Rule.Relocate("org.apache.commons.compress.**", "shadeio.commons.compress.@1")
   )
 
+  def thinJarAssembly: T[PathRef] = Task {
+
+    val bundledJars = defaultResolver().classpath(alwaysBundledDeps)
+
+    val assembled = Assembly.create(
+      destJar = Task.dest / "thin.jar",
+      inputPaths = Seq(jar().path) ++ bundledJars.map(_.path),
+      manifest = manifest(),
+      prependShellScript = None,
+      base = None,
+      assemblyRules = assemblyRules,
+      shader = mill.javalib.AssemblyModule.jarjarabramsWorker()
+    )
+    assembled.pathRef
+  }
+
   override def extraPublish = Seq(
     PublishInfo(assembly(), classifier = None, ivyConfig = "compile"),
-    PublishInfo(jar(), classifier = Some("thin"), ivyConfig = "compile")
+    PublishInfo(thinJarAssembly(), classifier = Some("thin"), ivyConfig = "compile")
   )
 
   override def sonatypeCentralReadTimeout: T[Int] = 600000
@@ -122,17 +138,21 @@ trait SparkModule extends Cross.Module2[String, String] with SbtModule with Sona
   }
 
   val poiVersion = "5.4.1"
+  val alwaysBundledDeps = Seq(
+    mvn"commons-io:commons-io:2.20.0",
+    mvn"org.apache.commons:commons-compress:1.27.1",
+    // POI needs to be bundled so that its bytecode can be rewritten
+    // to use the shaded version of commons-compress.
+    mvn"org.apache.poi:poi:$poiVersion",
+    mvn"org.apache.poi:poi-ooxml:$poiVersion",
+    mvn"org.apache.poi:poi-ooxml-lite:$poiVersion"
+  )
 
   override def mvnDeps = {
     val base = Seq(
-      mvn"org.apache.poi:poi:$poiVersion",
-      mvn"org.apache.poi:poi-ooxml:$poiVersion",
-      mvn"org.apache.poi:poi-ooxml-lite:$poiVersion",
       mvn"org.apache.xmlbeans:xmlbeans:5.3.0",
       mvn"com.norbitltd::spoiwo:2.2.1",
       mvn"com.github.pjfanning:excel-streaming-reader:5.1.1",
-      mvn"commons-io:commons-io:2.20.0",
-      mvn"org.apache.commons:commons-compress:1.27.1",
       mvn"org.apache.logging.log4j:log4j-api:2.24.3",
       mvn"com.zaxxer:SparseBitSet:1.3",
       mvn"org.apache.commons:commons-collections4:4.5.0",
@@ -141,7 +161,7 @@ trait SparkModule extends Cross.Module2[String, String] with SbtModule with Sona
       mvn"org.apache.commons:commons-math3:3.6.1",
       mvn"org.scala-lang.modules::scala-collection-compat:2.13.0",
       mvn"com.eed3si9n.ifdef::ifdef-annotation:0.4.1"
-    )
+    ) ++ alwaysBundledDeps
     if (sparkVersion >= "3.3.0") {
       base ++ Seq(mvn"org.apache.logging.log4j:log4j-core:2.24.3")
     } else {


### PR DESCRIPTION
### **User description**
Even in thin JAR


___

### **PR Type**
Enhancement


___

### **Description**
- Add always-shaded dependencies for thin JAR

- Implement thinJarAssembly to assemble shaded JAR

- Update publish config to use thinJarAssembly

- Refactor mvnDeps to append shaded dependencies


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["alwaysShadedDeps"] -- "classpath" --> B["shadedJars"]
  J["jar().path"] --> C["Assembly.create inputPaths"]
  B["shadedJars"] --> C
  C["Assembly.create"] -- "destJar thin.jar" --> D["thin.jar"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>build.mill</strong><dd><code>Add thinJarAssembly and shade dependencies</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

build.mill

<ul><li>Added <code>alwaysShadedDeps</code> sequence for commons-io and commons-compress<br> <li> Introduced <code>thinJarAssembly</code> task to create shaded thin JAR<br> <li> Updated <code>extraPublish</code> to use <code>thinJarAssembly</code> for thin classifier<br> <li> Refactored <code>mvnDeps</code> to remove and append shaded dependencies</ul>


</details>


  </td>
  <td><a href="https://github.com/nightscape/spark-excel/pull/990/files#diff-2b601da62851663bf0f9429195310d82df029448cc2f404c421798601585fb10">+22/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

