### PR TITLE
perf: Clip column range instead of filtering in V2 DataLocator

### DIFF
--- a/src/main/scala/dev/mauch/spark/excel/v2/DataLocator.scala
+++ b/src/main/scala/dev/mauch/spark/excel/v2/DataLocator.scala
@@ -37,10 +37,15 @@ trait DataLocator {
   def readFrom(workbook: Workbook): Iterator[Vector[Cell]]
 
   private def readCells(r: org.apache.poi.ss.usermodel.Row, colInd: Range): Vector[Cell] = {
-    val lastCellNum = r.getLastCellNum.toInt
-    val effectiveCols = if (lastCellNum < colInd.last + 1) colInd.start to math.min(colInd.last, lastCellNum - 1)
-    else colInd
-    effectiveCols.map(r.getCell(_, MissingCellPolicy.CREATE_NULL_AS_BLANK)).toVector
+    if (colInd.isEmpty) {
+      Vector.empty
+    } else {
+      val lastCellNum = r.getLastCellNum.toInt
+      val effectiveCols =
+        if (lastCellNum < colInd.last + 1) colInd.start to math.min(colInd.last, lastCellNum - 1)
+        else colInd
+      effectiveCols.map(r.getCell(_, MissingCellPolicy.CREATE_NULL_AS_BLANK)).toVector
+    }
   }
 
   def actualReadFromSheet(options: ExcelOptions, sheet: Sheet, rowInd: Range, colInd: Range): Iterator[Vector[Cell]] = {

--- a/src/main/scala/dev/mauch/spark/excel/v2/DataLocator.scala
+++ b/src/main/scala/dev/mauch/spark/excel/v2/DataLocator.scala
@@ -36,28 +36,25 @@ trait DataLocator {
     */
   def readFrom(workbook: Workbook): Iterator[Vector[Cell]]
 
+  private def readCells(r: org.apache.poi.ss.usermodel.Row, colInd: Range): Vector[Cell] = {
+    val lastCellNum = r.getLastCellNum.toInt
+    val effectiveCols = if (lastCellNum < colInd.last + 1) colInd.start to math.min(colInd.last, lastCellNum - 1)
+    else colInd
+    effectiveCols.map(r.getCell(_, MissingCellPolicy.CREATE_NULL_AS_BLANK)).toVector
+  }
+
   def actualReadFromSheet(options: ExcelOptions, sheet: Sheet, rowInd: Range, colInd: Range): Iterator[Vector[Cell]] = {
     if (options.keepUndefinedRows) {
       rowInd.iterator.map(rid => {
         val r = sheet.getRow(rid)
         if (r == null) { Vector.empty }
-        else {
-          colInd
-            .filter(_ < r.getLastCellNum)
-            .map(r.getCell(_, MissingCellPolicy.CREATE_NULL_AS_BLANK))
-            .toVector
-        }
+        else { readCells(r, colInd) }
       })
 
     } else {
       sheet.iterator.asScala
         .filter(r => rowInd.contains(r.getRowNum))
-        .map(r =>
-          colInd
-            .filter(_ < r.getLastCellNum)
-            .map(r.getCell(_, MissingCellPolicy.CREATE_NULL_AS_BLANK))
-            .toVector
-        )
+        .map(r => readCells(r, colInd))
         .filter(_.exists(_.getCellType != CellType.BLANK)) // #965 filter rows that are completely empty
     }
   }


### PR DESCRIPTION
## Summary
- Replaces `colInd.filter(_ < r.getLastCellNum)` with direct range clipping (`colInd.start to min(colInd.last, lastCellNum - 1)`), avoiding O(maxColumns) iteration per row
- Hoists `getLastCellNum` evaluation to once per row instead of once per column index
- Supersedes #720 with a more efficient approach (O(1) range construction vs O(n) `takeWhile`)

When `dataAddress` specifies only a starting cell, `colInd` becomes `1 to 16383`. For a file with 1M rows and 23 actual columns, the old code performed ~16 billion unnecessary comparisons. This change eliminates them entirely.

## Test plan
- [x] Existing integration tests pass (43/45, 2 pre-existing flaky failures in `returns all data rows when inferring schema`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)